### PR TITLE
Fix redirect of to_date in search function

### DIFF
--- a/modules/news/funcs/search.php
+++ b/modules/news/funcs/search.php
@@ -79,7 +79,7 @@ $to_date = $nv_Request->get_title( 'to_date', 'get', '', 0 );
 $date_array['to_date'] = preg_replace( '/[^0-9]/', '.', urldecode( $to_date ) );
 if( preg_match( '/^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{4})$/', $date_array['to_date'] ) )
 {
-	$base_url_rewrite .= '&from_date=' . $date_array['to_date'];
+	$base_url_rewrite .= '&to_date=' . $date_array['to_date'];
 }
 
 $page = $nv_Request->get_int( 'page', 'get', 1 );


### PR DESCRIPTION
Chageed from_date by to_date.
https://github.com/anhyeuviolet/nukeviet/blob/d5c60375ae07dd6f2fe32ca230502120db165501/modules/news/funcs/search.php#L82