### PR TITLE
Fix plugin rewrite_obsolute

### DIFF
--- a/includes/plugin/rewrite_obsolute.php
+++ b/includes/plugin/rewrite_obsolute.php
@@ -13,7 +13,7 @@ if (! defined('NV_MAINFILE')) {
 }
 
 //plugin rewrite obsolute url
-
+global $rewrite_values;
 foreach ($rewrite_values as $key => $value) {
     $rewrite_values[$key] = str_replace('"\\1', '"'.NV_MY_DOMAIN.'\\1', $value);
 }


### PR DESCRIPTION
Nguyên nhân: file footer.php thường được include từ function nên phải gọi biến global