### PR TITLE
supports PSR-0

### DIFF
--- a/includes/mainfile.php
+++ b/includes/mainfile.php
@@ -77,7 +77,7 @@ if (defined('NV_CONFIG_DIR')) {
 }
 
 // Vendor autoload
-require NV_ROOTDIR . '/vendor/autoload.php';
+$loader = require NV_ROOTDIR . '/vendor/autoload.php';
 require NV_ROOTDIR . '/includes/xtemplate.class.php';
 
 // Xac dinh IP cua client


### PR DESCRIPTION
supports PSR-0 And load other class from other folder
$loader = require __DIR__ . '/vendor/autoload.php';
$loader->add('Acme\\Test\\', __DIR__);