### PR TITLE
Fix DB access deny when install if db password has special character.

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -319,7 +319,7 @@ if ($step == 1) {
     $db_config['dbhost'] = $nv_Request->get_string('dbhost', 'post', $db_config['dbhost']);
     $db_config['dbname'] = $nv_Request->get_string('dbname', 'post', $db_config['dbname']);
     $db_config['dbuname'] = $nv_Request->get_string('dbuname', 'post', $db_config['dbuname']);
-    $db_config['dbpass'] = $nv_Request->get_string('dbpass', 'post', $db_config['dbpass']);
+    $db_config['dbpass'] = html_entity_decode( $nv_Request->get_string('dbpass', 'post', $db_config['dbpass']) );
     $db_config['prefix'] = $nv_Request->get_string('prefix', 'post', $db_config['prefix']);
     $db_config['dbport'] = $nv_Request->get_string('dbport', 'post', $db_config['dbport']);
     $db_config['db_detete'] = $nv_Request->get_int('db_detete', 'post', $db_config['dbdetete']);


### PR DESCRIPTION
Example: In step 5, when enter db pass: '7?o4UIG[bGU7zoW*.' and submit. It become '7?o4UIG&#91;bGU7zoW*.' and throw exception access deny.  ( [ -> &# 91; )