### PR TITLE
Update Gfonts.php

### DIFF
--- a/vendor/vinades/nukeviet/Client/Gfonts.php
+++ b/vendor/vinades/nukeviet/Client/Gfonts.php
@@ -198,7 +198,7 @@ class Gfonts
             }
         }
 
-        return implode($_fonts, '|');
+        return implode('|', $_fonts);
     }
 
     /**


### PR DESCRIPTION
Fix "implode() - passing glue string after array is deprecated. swap the parameters" on PHP>=7.4
(Passing the glue after the pieces (i.e. not using the documented order of parameters) has been deprecated - https://www.php.net/manual/en/function.implode.php)