### PR TITLE
Fix javascript error in FTP configuration

### DIFF
--- a/themes/admin_default/js/settings.js
+++ b/themes/admin_default/js/settings.js
@@ -113,13 +113,16 @@ $(document).ready(function(){
 
 		$(this).attr('disabled', 'disabled');
 
-		var data = 'ftp_server=' + ftp_server + '&ftp_port=' + ftp_port + '&ftp_user_name=' + ftp_user_name + '&ftp_user_pass=' + ftp_user_pass + '&tetectftp=1';
-		var url = CFG.detect_ftp;
-
 		$.ajax({
 			type : "POST",
-			url : url,
-			data : data,
+			url : CFG.detect_ftp,
+			data : {
+                'ftp_server':ftp_server,
+                'ftp_port':ftp_port,
+                'ftp_user_name':ftp_user_name,
+                'ftp_user_pass':ftp_user_pass,
+                'tetectftp':1
+            },
 			success : function(c) {
 				c = c.split('|');
 				if (c[0] == 'OK') {


### PR DESCRIPTION
Khi click vào nút xác định tự động Remote path, nếu mật khẩu có dấu "&" sẽ luôn có kết quả false