### PR TITLE
Potential Cross-site Scripting (XSS) Errors

### DIFF
--- a/includes/core/theme_functions.php
+++ b/includes/core/theme_functions.php
@@ -276,12 +276,16 @@ function nv_xmlOutput($content, $lastModified)
 }
 
 /**
- * @param array $channel
- * @param array $items
+ * nv_rss_generate()
+ * 
+ * @param mixed $channel
+ * @param mixed $items
+ * @param mixed $atomlink
  * @param string $timemode
- * @param boolean $noindex
+ * @param bool $noindex
+ * @return void
  */
-function nv_rss_generate($channel, $items, $timemode = 'GMT', $noindex = true)
+function nv_rss_generate($channel, $items, $atomlink, $timemode = 'GMT', $noindex = true)
 {
     global $global_config, $client_info;
 
@@ -293,7 +297,7 @@ function nv_rss_generate($channel, $items, $timemode = 'GMT', $noindex = true)
 
     $channel['generator'] = 'NukeViet v4.0';
     $channel['title'] = nv_htmlspecialchars($channel['title']);
-    $channel['atomlink'] = str_replace('&', '&amp;', $client_info['selfurl']);
+    $channel['atomlink'] = NV_MY_DOMAIN . nv_url_rewrite($atomlink, true);
     $channel['lang'] = $global_config['site_lang'];
     $channel['copyright'] = $global_config['site_name'];
 
@@ -308,14 +312,6 @@ function nv_rss_generate($channel, $items, $timemode = 'GMT', $noindex = true)
     $channel['link'] = nv_url_rewrite($channel['link'], true);
     if (strpos($channel['link'], NV_MY_DOMAIN) !== 0) {
         $channel['link'] = NV_MY_DOMAIN . $channel['link'];
-    }
-
-    if (preg_match('/^' . nv_preg_quote(NV_MY_DOMAIN . NV_BASE_SITEURL) . '(.+)$/', $channel['atomlink'], $matches)) {
-        $channel['atomlink'] = NV_BASE_SITEURL . $matches[1];
-    }
-    $channel['atomlink'] = nv_url_rewrite($channel['atomlink'], true);
-    if (strpos($channel['atomlink'], NV_MY_DOMAIN) !== 0) {
-        $channel['atomlink'] = NV_MY_DOMAIN . $channel['atomlink'];
     }
 
     $channel['pubDate'] = 0;

--- a/includes/mainfile.php
+++ b/includes/mainfile.php
@@ -23,7 +23,7 @@ define('NV_CURRENTTIME', isset($_SERVER['REQUEST_TIME']) ? $_SERVER['REQUEST_TIM
 
 // Khong cho xac dinh tu do cac variables
 $db_config = $global_config = $module_config = $client_info = $user_info = $admin_info = $sys_info = $lang_global = $lang_module = $rss = $nv_vertical_menu = $array_mod_title = $content_type = $submenu = $error_info = $countries = $loadScript = $headers = array();
-$page_title = $key_words = $canonicalUrl = $mod_title = $editor_password = $my_head = $my_footer = $description = $contents = '';
+$page_title = $key_words = $page_url = $canonicalUrl = $mod_title = $editor_password = $my_head = $my_footer = $description = $contents = '';
 $editor = false;
 
 // Ket noi voi cac file constants, config

--- a/modules/banners/funcs/addads.php
+++ b/modules/banners/funcs/addads.php
@@ -13,6 +13,16 @@ if (!defined('NV_IS_MOD_BANNERS')) {
 }
 
 $page_title = $module_info['site_title'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 if (!defined('NV_IS_BANNER_CLIENT')) {
     nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name);

--- a/modules/banners/funcs/main.php
+++ b/modules/banners/funcs/main.php
@@ -28,6 +28,17 @@ foreach ($global_array_plans as $row) {
 }
 
 $page_title = $module_info['site_title'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
+
 $contents = nv_banner_theme_main($contents, $manament);
 
 include NV_ROOTDIR . '/includes/header.php';

--- a/modules/banners/funcs/stats.php
+++ b/modules/banners/funcs/stats.php
@@ -13,6 +13,16 @@ if (!defined('NV_IS_MOD_BANNERS')) {
 }
 
 $page_title = $lang_module['stats_views'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 if (!defined('NV_IS_BANNER_CLIENT')) {
     nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name);

--- a/modules/comment/blocks/global.block_facebook_comment_box.php
+++ b/modules/comment/blocks/global.block_facebook_comment_box.php
@@ -83,7 +83,7 @@ if (!nv_function_exists('nv_facebook_comment_box_blocks')) {
      */
     function nv_facebook_comment_box_blocks($block_config)
     {
-        global $client_info, $module_name;
+        global $page_url, $module_name;
         $content = '';
         if (!defined('FACEBOOK_JSSDK')) {
             $lang = (NV_LANG_DATA == 'vi') ? 'vi_VN' : 'en_US';
@@ -101,7 +101,9 @@ if (!nv_function_exists('nv_facebook_comment_box_blocks')) {
 			</script>";
             define('FACEBOOK_JSSDK', true);
         }
-        $content .= '<div class="fb-comments" data-href="' . $client_info['selfurl'] . '" data-num-posts="' . $block_config['numpost'] . '" data-width="' . $block_config['width'] . '" data-colorscheme="' . $block_config['scheme'] . '"></div>';
+        
+        $href = !empty($page_url) ? NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true) : '';
+        $content .= '<div class="fb-comments" data-href="' . $href . '" data-num-posts="' . $block_config['numpost'] . '" data-width="' . $block_config['width'] . '" data-colorscheme="' . $block_config['scheme'] . '"></div>';
 
         return $content;
     }

--- a/modules/contact/funcs/main.php
+++ b/modules/contact/funcs/main.php
@@ -265,16 +265,16 @@ $key_words = $module_info['keywords'];
 $mod_title = isset($lang_module['main_title']) ? $lang_module['main_title'] : $module_info['custom_title'];
 
 $full_theme = true;
-$base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
 if (!empty($alias_department)) {
-    $base_url .= '&amp;' . NV_OP_VARIABLE . '=' . $alias_department;
-    if (isset($array_op[1]) and $array_op[1] == 0) {
-        $base_url .= '/0';
+    $page_url .= '&amp;' . NV_OP_VARIABLE . '=' . $alias_department;
+    if (isset($array_op[1]) and $array_op[1] === '0') {
+        $page_url .= '/0';
         $full_theme = false;
     }
 }
 
-$base_url_rewrite = nv_url_rewrite($base_url, true);
+$base_url_rewrite = nv_url_rewrite($page_url, true);
 $base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
 if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
     $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
@@ -292,7 +292,7 @@ $array_content = array(
     'bodytext' => $module_config[$module_name]['bodytext']
 );
 
-$contents = contact_main_theme($array_content, $array_department, $catsName, $base_url, NV_CHECK_SESSION);
+$contents = contact_main_theme($array_content, $array_department, $catsName, $page_url, NV_CHECK_SESSION);
 
 include NV_ROOTDIR . '/includes/header.php';
 echo nv_site_theme($contents, $full_theme);

--- a/modules/feeds/funcs/main.php
+++ b/modules/feeds/funcs/main.php
@@ -79,8 +79,16 @@ function nv_get_sub_rss_link($rssarray, $id)
 }
 
 $page_title = $module_info['site_title'];
-if (isset($array_op[0])) {
-    nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name);
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
+
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
 }
 
 $array = '';

--- a/modules/news/funcs/content.php
+++ b/modules/news/funcs/content.php
@@ -42,6 +42,8 @@ if (defined('NV_EDITOR')) {
 
 $page_title = $lang_module['content'];
 $key_words = $module_info['keywords'];
+$page_url = $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 // check user post content
 $array_post_config = array();
@@ -106,8 +108,6 @@ if ($array_post_user['postcontent']) {
     $array_post_user['addcontent'] = 1;
 }
 
-$base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $op;
-
 if (!$array_post_user['addcontent']) {
     if (defined('NV_IS_USER')) {
         $array_temp['urlrefresh'] = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA;
@@ -152,6 +152,9 @@ $selectthemes = (!empty($site_mods[$module_name]['theme'])) ? $site_mods[$module
 $layout_array = nv_scandir(NV_ROOTDIR . '/themes/' . $selectthemes . '/layout', $global_config['check_op_layout']);
 
 if ($nv_Request->isset_request('contentid', 'get,post') and $fcheckss == $checkss) {
+    $page_url .= '&amp;contentid=' . $contentid . '&amp;checkss=' . $fcheckss;
+    $canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
+
     if ($contentid > 0) {
         $rowcontent_old = $db->query('SELECT * FROM ' . NV_PREFIXLANG . '_' . $module_data . '_rows WHERE id=' . $contentid . ' AND admin_id= ' . $user_info['userid'] . ' AND status<=' . $global_code_defined['row_locked_status'])->fetch();
         $contentid = (isset($rowcontent_old['id'])) ? intval($rowcontent_old['id']) : 0;
@@ -654,6 +657,7 @@ if ($nv_Request->isset_request('contentid', 'get,post') and $fcheckss == $checks
 
     if (isset($array_op[1]) and substr($array_op[1], 0, 5) == 'page-') {
         $page = intval(substr($array_op[1], 5));
+        $page_url .= '/page-' . $page;
     }
 
     $contents = "<div style=\"border: 1px solid #ccc;margin: 10px; font-size: 15px; font-weight: bold; text-align: center;\"><a href=\"" . $base_url . "&amp;contentid=0&checkss=" . md5("0" . NV_CHECK_SESSION) . "\">" . $lang_module['add_content'] . "</a></h1></div>";

--- a/modules/news/funcs/detail.php
+++ b/modules/news/funcs/detail.php
@@ -24,182 +24,180 @@ if (empty($module_config[$module_name]['identify_cat_change'])) {
 }
 $news_contents = $query->fetch();
 
-if (!empty($news_contents)) {
-    $body_contents = $db_slave->query('SELECT titlesite, description, bodyhtml, keywords, sourcetext, files, layout_func, imgposition, copyright, allowed_send, allowed_print, allowed_save FROM ' . NV_PREFIXLANG . '_' . $module_data . '_detail where id=' . $news_contents['id'])->fetch();
-    $news_contents = array_merge($news_contents, $body_contents);
-    unset($body_contents);
+if (empty($news_contents)) {
+    $redirect = '<meta http-equiv="Refresh" content="3;URL=' . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name, true) . '" />';
+    nv_info_die($lang_global['error_404_title'], $lang_global['error_404_title'], $lang_global['error_404_content'] . $redirect, 404);
+}
 
-    // Tải về đính kèm
-    if ($nv_Request->isset_request('download', 'get')) {
-        $fileid = $nv_Request->get_int('id', 'get', 0);
+$body_contents = $db_slave->query('SELECT titlesite, description, bodyhtml, keywords, sourcetext, files, layout_func, imgposition, copyright, allowed_send, allowed_print, allowed_save FROM ' . NV_PREFIXLANG . '_' . $module_data . '_detail where id=' . $news_contents['id'])->fetch();
+$news_contents = array_merge($news_contents, $body_contents);
+unset($body_contents);
 
-        $news_contents['files'] = explode(',', $news_contents['files']);
+// Tải về đính kèm
+if ($nv_Request->isset_request('download', 'get')) {
+    $fileid = $nv_Request->get_int('id', 'get', 0);
 
-        if (!isset($news_contents['files'][$fileid])) {
-            nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name, true);
-        }
+    $news_contents['files'] = explode(',', $news_contents['files']);
 
-        if (!file_exists(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid])) {
-            nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name, true);
-        }
-
-        $file_info = pathinfo(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid]);
-        $download = new NukeViet\Files\Download(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid], $file_info['dirname'], $file_info['basename'], true);
-        $download->download_file();
-        exit();
+    if (!isset($news_contents['files'][$fileid])) {
+        nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name, true);
     }
 
-    // Xem đính kèm dạng PDF
-    if ($nv_Request->isset_request('pdf', 'get')) {
-        $fileid = $nv_Request->get_int('id', 'get', 0);
-
-        $news_contents['files'] = explode(',', $news_contents['files']);
-
-        if (!isset($news_contents['files'][$fileid])) {
-            nv_info_die($lang_global['error_404_title'], $lang_global['error_404_title'], $lang_global['error_404_content'], 404);
-        }
-
-        if (!file_exists(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid])) {
-            nv_info_die($lang_global['error_404_title'], $lang_global['error_404_title'], $lang_global['error_404_content'], 404);
-        }
-
-        $file_url = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $global_array_cat[$news_contents['catid']]['alias'] . '/' . $news_contents['alias'] . '-' . $news_contents['id'] . $global_config['rewrite_exturl'], true) . '?download=1&id=' . $fileid;
-
-        $contents = nv_theme_viewpdf($file_url);
-        nv_htmlOutput($contents);
+    if (!file_exists(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid])) {
+        nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name, true);
     }
 
-    // Kiểm tra URL, không cho đánh tùy ý phần alias
-    $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $global_array_cat[$news_contents['catid']]['alias'] . '/' . $news_contents['alias'] . '-' . $news_contents['id'] . $global_config['rewrite_exturl'];
-    $base_url_rewrite = nv_url_rewrite($base_url, true);
-    $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
-    if (strpos($_SERVER['REQUEST_URI'], $base_url_check) !== 0 and strpos(NV_MY_DOMAIN . $_SERVER['REQUEST_URI'], $base_url_check) !== 0) {
-        nv_redirect_location($base_url_rewrite);
-    }
-    $news_contents['link'] = $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+    $file_info = pathinfo(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid]);
+    $download = new NukeViet\Files\Download(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid], $file_info['dirname'], $file_info['basename'], true);
+    $download->download_file();
+    exit();
+}
 
-    /*
-     * Không có quyền xem bài viết thì dừng
-     * Lưu ý tới đây thì $catid này đã là $catid chính thức vì không chính thức thì
-     * bên trên đã được chuyển hướng
-     */
-    if (!nv_user_in_groups($global_array_cat[$catid]['groups_view'])) {
-        $contents = no_permission($global_array_cat[$catid]['groups_view']);
+// Xem đính kèm dạng PDF
+if ($nv_Request->isset_request('pdf', 'get')) {
+    $fileid = $nv_Request->get_int('id', 'get', 0);
 
-        include NV_ROOTDIR . '/includes/header.php';
-        echo nv_site_theme($contents);
-        include NV_ROOTDIR . '/includes/footer.php';
+    $news_contents['files'] = explode(',', $news_contents['files']);
+
+    if (!isset($news_contents['files'][$fileid])) {
+        nv_info_die($lang_global['error_404_title'], $lang_global['error_404_title'], $lang_global['error_404_content'], 404);
     }
 
-    // Mở bài viết sang nguồn tin chính thức
-    if ($news_contents['external_link']) {
-        nv_redirect_location($news_contents['sourcetext']);
+    if (!file_exists(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid])) {
+        nv_info_die($lang_global['error_404_title'], $lang_global['error_404_title'], $lang_global['error_404_content'], 404);
     }
 
-    $page_title = empty($news_contents['titlesite']) ? $news_contents['title'] : $news_contents['titlesite'];
+    $file_url = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $global_array_cat[$news_contents['catid']]['alias'] . '/' . $news_contents['alias'] . '-' . $news_contents['id'] . $global_config['rewrite_exturl'], true) . '?download=1&id=' . $fileid;
 
-    $show_no_image = $module_config[$module_name]['show_no_image'];
+    $contents = nv_theme_viewpdf($file_url);
+    nv_htmlOutput($contents);
+}
 
-    if (defined('NV_IS_MODADMIN') or ($news_contents['status'] == 1 and $news_contents['publtime'] < NV_CURRENTTIME and ($news_contents['exptime'] == 0 or $news_contents['exptime'] > NV_CURRENTTIME))) {
-        $time_set = $nv_Request->get_int($module_data . '_' . $op . '_' . $id, 'session');
-        if (empty($time_set)) {
-            $nv_Request->set_Session($module_data . '_' . $op . '_' . $id, NV_CURRENTTIME);
-            $query = 'UPDATE ' . NV_PREFIXLANG . '_' . $module_data . '_rows SET hitstotal=hitstotal+1 WHERE id=' . $id;
+// Kiểm tra URL, không cho đánh tùy ý phần alias
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $global_array_cat[$news_contents['catid']]['alias'] . '/' . $news_contents['alias'] . '-' . $news_contents['id'] . $global_config['rewrite_exturl'];
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
+if (strpos($_SERVER['REQUEST_URI'], $base_url_check) !== 0 and strpos(NV_MY_DOMAIN . $_SERVER['REQUEST_URI'], $base_url_check) !== 0) {
+    nv_redirect_location($base_url_rewrite);
+}
+$news_contents['link'] = $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+
+/*
+ * Không có quyền xem bài viết thì dừng
+ * Lưu ý tới đây thì $catid này đã là $catid chính thức vì không chính thức thì
+ * bên trên đã được chuyển hướng
+ */
+if (!nv_user_in_groups($global_array_cat[$catid]['groups_view'])) {
+    $contents = no_permission($global_array_cat[$catid]['groups_view']);
+
+    include NV_ROOTDIR . '/includes/header.php';
+    echo nv_site_theme($contents);
+    include NV_ROOTDIR . '/includes/footer.php';
+}
+
+// Mở bài viết sang nguồn tin chính thức
+if ($news_contents['external_link']) {
+    nv_redirect_location($news_contents['sourcetext']);
+}
+
+$page_title = empty($news_contents['titlesite']) ? $news_contents['title'] : $news_contents['titlesite'];
+
+$show_no_image = $module_config[$module_name]['show_no_image'];
+
+if (defined('NV_IS_MODADMIN') or ($news_contents['status'] == 1 and $news_contents['publtime'] < NV_CURRENTTIME and ($news_contents['exptime'] == 0 or $news_contents['exptime'] > NV_CURRENTTIME))) {
+    $time_set = $nv_Request->get_int($module_data . '_' . $op . '_' . $id, 'session');
+    if (empty($time_set)) {
+        $nv_Request->set_Session($module_data . '_' . $op . '_' . $id, NV_CURRENTTIME);
+        $query = 'UPDATE ' . NV_PREFIXLANG . '_' . $module_data . '_rows SET hitstotal=hitstotal+1 WHERE id=' . $id;
+        $db->query($query);
+
+        $array_catid = explode(',', $news_contents['listcatid']);
+        foreach ($array_catid as $catid_i) {
+            $query = 'UPDATE ' . NV_PREFIXLANG . '_' . $module_data . '_' . $catid_i . ' SET hitstotal=hitstotal+1 WHERE id=' . $id;
             $db->query($query);
-
-            $array_catid = explode(',', $news_contents['listcatid']);
-            foreach ($array_catid as $catid_i) {
-                $query = 'UPDATE ' . NV_PREFIXLANG . '_' . $module_data . '_' . $catid_i . ' SET hitstotal=hitstotal+1 WHERE id=' . $id;
-                $db->query($query);
-            }
         }
-        $news_contents['showhometext'] = $module_config[$module_name]['showhometext'];
-        if (!empty($news_contents['homeimgfile'])) {
-            $src = $alt = $note = '';
-            $width = $height = 0;
-            if ($news_contents['homeimgthumb'] == 1 and $news_contents['imgposition'] == 1) {
-                $src = NV_BASE_SITEURL . NV_FILES_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile'];
-                $news_contents['homeimgfile'] = NV_BASE_SITEURL . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile'];
+    }
+    $news_contents['showhometext'] = $module_config[$module_name]['showhometext'];
+    if (!empty($news_contents['homeimgfile'])) {
+        $src = $alt = $note = '';
+        $width = $height = 0;
+        if ($news_contents['homeimgthumb'] == 1 and $news_contents['imgposition'] == 1) {
+            $src = NV_BASE_SITEURL . NV_FILES_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile'];
+            $news_contents['homeimgfile'] = NV_BASE_SITEURL . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile'];
+            $width = $module_config[$module_name]['homewidth'];
+        } elseif ($news_contents['homeimgthumb'] == 3) {
+            $src = $news_contents['homeimgfile'];
+            $width = ($news_contents['imgposition'] == 1) ? $module_config[$module_name]['homewidth'] : $module_config[$module_name]['imagefull'];
+        } elseif (file_exists(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile'])) {
+            $src = NV_BASE_SITEURL . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile'];
+            if ($news_contents['imgposition'] == 1) {
                 $width = $module_config[$module_name]['homewidth'];
-            } elseif ($news_contents['homeimgthumb'] == 3) {
-                $src = $news_contents['homeimgfile'];
-                $width = ($news_contents['imgposition'] == 1) ? $module_config[$module_name]['homewidth'] : $module_config[$module_name]['imagefull'];
-            } elseif (file_exists(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile'])) {
-                $src = NV_BASE_SITEURL . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile'];
-                if ($news_contents['imgposition'] == 1) {
-                    $width = $module_config[$module_name]['homewidth'];
+            } else {
+                $imagesize = @getimagesize(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile']);
+                if ($imagesize[0] > 0 and $imagesize[0] > $module_config[$module_name]['imagefull']) {
+                    $width = $module_config[$module_name]['imagefull'];
                 } else {
-                    $imagesize = @getimagesize(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile']);
-                    if ($imagesize[0] > 0 and $imagesize[0] > $module_config[$module_name]['imagefull']) {
-                        $width = $module_config[$module_name]['imagefull'];
-                    } else {
-                        $width = $imagesize[0];
-                    }
+                    $width = $imagesize[0];
                 }
-                $news_contents['homeimgfile'] = $src;
             }
+            $news_contents['homeimgfile'] = $src;
+        }
 
-            if (!empty($src)) {
-                $meta_property['og:image'] = (preg_match('/^(http|https|ftp|gopher)\:\/\//', $news_contents['homeimgfile'])) ? $news_contents['homeimgfile'] : NV_MY_DOMAIN . $news_contents['homeimgfile'];
-                if ($news_contents['imgposition'] > 0) {
-                    $news_contents['image'] = [
-                        'src' => $src,
-                        'width' => $width,
-                        'alt' => (empty($news_contents['homeimgalt'])) ? $news_contents['title'] : $news_contents['homeimgalt'],
-                        'note' => $news_contents['homeimgalt'],
-                        'position' => $news_contents['imgposition']
-                    ];
-                }
-            } elseif (!empty($show_no_image)) {
-                $meta_property['og:image'] = NV_MY_DOMAIN . NV_BASE_SITEURL . $show_no_image;
+        if (!empty($src)) {
+            $meta_property['og:image'] = (preg_match('/^(http|https|ftp|gopher)\:\/\//', $news_contents['homeimgfile'])) ? $news_contents['homeimgfile'] : NV_MY_DOMAIN . $news_contents['homeimgfile'];
+            if ($news_contents['imgposition'] > 0) {
+                $news_contents['image'] = [
+                    'src' => $src,
+                    'width' => $width,
+                    'alt' => (empty($news_contents['homeimgalt'])) ? $news_contents['title'] : $news_contents['homeimgalt'],
+                    'note' => $news_contents['homeimgalt'],
+                    'position' => $news_contents['imgposition']
+                ];
             }
         } elseif (!empty($show_no_image)) {
             $meta_property['og:image'] = NV_MY_DOMAIN . NV_BASE_SITEURL . $show_no_image;
         }
-
-        // File download
-        if (!empty($news_contents['files'])) {
-            $news_contents['files'] = explode(',', $news_contents['files']);
-            $files = $news_contents['files'];
-            $news_contents['files'] = [];
-
-            foreach ($files as $file_id => $file) {
-                $is_localfile = (!nv_is_url($file));
-                $file_title = $is_localfile ? basename($file) : $lang_module['click_to_download'];
-                $news_contents['files'][] = [
-                    'title' => $file_title,
-                    'key' => md5($file_id . $file_title),
-                    'ext' => nv_getextension($file_title),
-                    'titledown' => $lang_module['download'] . ' ' . (count($files) > 1 ? $file_id + 1 : ''),
-                    'src' => NV_BASE_SITEURL . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $file,
-                    'url' => $is_localfile ? ($base_url . '&amp;download=1&amp;id=' . $file_id) : $file,
-                    'urlpdf' => $base_url . '&amp;pdf=1&amp;id=' . $file_id,
-                    'urldoc' => $is_localfile ? $file : ('https://docs.google.com/viewer?embedded=true&url=' . NV_MY_DOMAIN . '/' . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $file)
-                ];
-            }
-        }
-
-        $publtime = intval($news_contents['publtime']);
-        $meta_property['og:type'] = 'article';
-        $meta_property['article:published_time'] = date('Y-m-dTH:i:s', $publtime);
-        $meta_property['article:modified_time'] = date('Y-m-dTH:i:s', $news_contents['edittime']);
-        if ($news_contents['exptime']) {
-            $meta_property['article:expiration_time'] = date('Y-m-dTH:i:s', $news_contents['exptime']);
-        }
-        $meta_property['article:section'] = $global_array_cat[$news_contents['catid']]['title'];
+    } elseif (!empty($show_no_image)) {
+        $meta_property['og:image'] = NV_MY_DOMAIN . NV_BASE_SITEURL . $show_no_image;
     }
 
-    if (defined('NV_IS_MODADMIN') and $news_contents['status'] != 1) {
-        $alert = sprintf($lang_module['status_alert'], $lang_module['status_' . $news_contents['status']]);
-        $my_footer .= "<script type=\"text/javascript\">alert('" . $alert . "')</script>";
-        $news_contents['allowed_send'] = 0;
-        $module_config[$module_name]['socialbutton'] = 0;
+    // File download
+    if (!empty($news_contents['files'])) {
+        $news_contents['files'] = explode(',', $news_contents['files']);
+        $files = $news_contents['files'];
+        $news_contents['files'] = [];
+
+        foreach ($files as $file_id => $file) {
+            $is_localfile = (!nv_is_url($file));
+            $file_title = $is_localfile ? basename($file) : $lang_module['click_to_download'];
+            $news_contents['files'][] = [
+                'title' => $file_title,
+                'key' => md5($file_id . $file_title),
+                'ext' => nv_getextension($file_title),
+                'titledown' => $lang_module['download'] . ' ' . (count($files) > 1 ? $file_id + 1 : ''),
+                'src' => NV_BASE_SITEURL . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $file,
+                'url' => $is_localfile ? ($page_url . '&amp;download=1&amp;id=' . $file_id) : $file,
+                'urlpdf' => $page_url . '&amp;pdf=1&amp;id=' . $file_id,
+                'urldoc' => $is_localfile ? $file : ('https://docs.google.com/viewer?embedded=true&url=' . NV_MY_DOMAIN . '/' . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $file)
+            ];
+        }
     }
+
+    $publtime = intval($news_contents['publtime']);
+    $meta_property['og:type'] = 'article';
+    $meta_property['article:published_time'] = date('Y-m-dTH:i:s', $publtime);
+    $meta_property['article:modified_time'] = date('Y-m-dTH:i:s', $news_contents['edittime']);
+    if ($news_contents['exptime']) {
+        $meta_property['article:expiration_time'] = date('Y-m-dTH:i:s', $news_contents['exptime']);
+    }
+    $meta_property['article:section'] = $global_array_cat[$news_contents['catid']]['title'];
 }
 
-if ($publtime == 0) {
-    $redirect = '<meta http-equiv="Refresh" content="3;URL=' . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name, true) . '" />';
-    nv_info_die($lang_global['error_404_title'], $lang_global['error_404_title'], $lang_global['error_404_content'] . $redirect, 404);
+if (defined('NV_IS_MODADMIN') and $news_contents['status'] != 1) {
+    $alert = sprintf($lang_module['status_alert'], $lang_module['status_' . $news_contents['status']]);
+    $my_footer .= "<script type=\"text/javascript\">alert('" . $alert . "')</script>";
+    $news_contents['allowed_send'] = 0;
+    $module_config[$module_name]['socialbutton'] = 0;
 }
 
 $news_contents['url_sendmail'] = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=sendmail/' . $global_array_cat[$catid]['alias'] . '/' . $news_contents['alias'] . '-' . $news_contents['id'] . $global_config['rewrite_exturl'], true);

--- a/modules/news/funcs/groups.php
+++ b/modules/news/funcs/groups.php
@@ -13,101 +13,126 @@
  }
 
 $show_no_image = $module_config[$module_name]['show_no_image'];
+
 if (isset($array_op[1])) {
     $alias = trim($array_op[1]);
     $page = (isset($array_op[2]) and substr($array_op[2], 0, 5) == 'page-') ? intval(substr($array_op[2], 5)) : 1;
+    $page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $module_info['alias']['groups'];
 
     $stmt = $db_slave->prepare('SELECT bid, title, alias, image, description, keywords FROM ' . NV_PREFIXLANG . '_' . $module_data . '_block_cat WHERE alias= :alias');
     $stmt->bindParam(':alias', $alias, PDO::PARAM_STR);
     $stmt->execute();
     list($bid, $page_title, $alias, $image_group, $description, $key_words) = $stmt->fetch(3);
-    if ($bid > 0) {
-        $base_url_rewrite = $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $module_info['alias']['groups'] . '/' . $alias;
+    if (!$bid) {
+        nv_redirect_location($page_url);
+    }
 
-        if ($page > 1) {
-            $page_title .= NV_TITLEBAR_DEFIS . $lang_global['page'] . ' ' . $page;
-            $base_url_rewrite .= '/page-' . $page;
+    $page_url .= '/' . $alias;
+    $base_url = $page_url;
+
+    if ($page > 1) {
+        $page_title .= NV_TITLEBAR_DEFIS . $lang_global['page'] . ' ' . $page;
+        $page_url .= '/page-' . $page;
+    }
+
+    $base_url_rewrite = nv_url_rewrite($page_url, true);
+    $base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+    if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+        $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+    } elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+        nv_redirect_location($base_url_rewrite_location);
+    } else {
+        $canonicalUrl = $base_url_rewrite;
+    }
+
+    $array_mod_title[] = array(
+        'catid' => 0,
+        'title' => $page_title,
+        'link' => $base_url
+    );
+
+    $item_array = array();
+    $end_weight = 0;
+
+    $db_slave->sqlreset()
+        ->select('COUNT(*)')
+        ->from(NV_PREFIXLANG . '_' . $module_data . '_rows t1')
+        ->join('INNER JOIN ' . NV_PREFIXLANG . '_' . $module_data . '_block t2 ON t1.id = t2.id')
+        ->where('t2.bid= ' . $bid . ' AND t1.status= 1');
+
+    $num_items = $db_slave->query($db_slave->sql())
+        ->fetchColumn();
+
+    $db_slave->select('t1.id, t1.catid, t1.admin_id, t1.author, t1.sourceid, t1.addtime, t1.edittime, t1.publtime, t1.title, t1.alias, t1.hometext, t1.homeimgfile, t1.homeimgalt, t1.homeimgthumb, t1.allowed_rating, t1.external_link, t1.hitstotal, t1.hitscm, t1.total_rating, t1.click_rating, t2.weight')
+        ->order('t2.weight ASC')
+        ->limit($per_page)
+        ->offset(($page - 1) * $per_page);
+
+    $result = $db_slave->query($db_slave->sql());
+    while ($item = $result->fetch()) {
+        if ($item['homeimgthumb'] == 1) {
+            // image thumb
+            $item['src'] = NV_BASE_SITEURL . NV_FILES_DIR . '/' . $module_upload . '/' . $item['homeimgfile'];
+        } elseif ($item['homeimgthumb'] == 2) {
+            // image file
+            $item['src'] = NV_BASE_SITEURL . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $item['homeimgfile'];
+        } elseif ($item['homeimgthumb'] == 3) {
+            // image url
+            $item['src'] = $item['homeimgfile'];
+        } elseif (!empty($show_no_image)) {
+            // no image
+            $item['src'] = NV_BASE_SITEURL . $show_no_image;
+        } else {
+            $item['src'] = '';
         }
-        $base_url_rewrite = nv_url_rewrite($base_url_rewrite, true);
-        if ($_SERVER['REQUEST_URI'] != $base_url_rewrite and NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite) {
-            nv_redirect_location($base_url_rewrite);
-        }
 
-        $array_mod_title[] = array(
-            'catid' => 0,
-            'title' => $page_title,
-            'link' => $base_url
-        );
+        $item['alt'] = !empty($item['homeimgalt']) ? $item['homeimgalt'] : $item['title'];
+        $item['width'] = $module_config[$module_name]['homewidth'];
 
-        $item_array = array();
-        $end_weight = 0;
+        $end_weight = $item['weight'];
 
+        $item['link'] = $global_array_cat[$item['catid']]['link'] . '/' . $item['alias'] . '-' . $item['id'] . $global_config['rewrite_exturl'];
+        $item_array[] = $item;
+    }
+    $result->closeCursor();
+    unset($query, $row);
+
+    $item_array_other = array();
+    if ($st_links > 0) {
         $db_slave->sqlreset()
-            ->select('COUNT(*)')
+            ->select('t1.id, t1.catid, t1.addtime, t1.edittime, t1.publtime, t1.title, t1.alias, t1.hitstotal, t1.external_link')
             ->from(NV_PREFIXLANG . '_' . $module_data . '_rows t1')
             ->join('INNER JOIN ' . NV_PREFIXLANG . '_' . $module_data . '_block t2 ON t1.id = t2.id')
-            ->where('t2.bid= ' . $bid . ' AND t1.status= 1');
-
-        $num_items = $db_slave->query($db_slave->sql())->fetchColumn();
-
-        $db_slave->select('t1.id, t1.catid, t1.admin_id, t1.author, t1.sourceid, t1.addtime, t1.edittime, t1.publtime, t1.title, t1.alias, t1.hometext, t1.homeimgfile, t1.homeimgalt, t1.homeimgthumb, t1.allowed_rating, t1.external_link, t1.hitstotal, t1.hitscm, t1.total_rating, t1.click_rating, t2.weight')
+            ->where('t2.bid= ' . $bid . ' AND t2.weight > ' . $end_weight)
             ->order('t2.weight ASC')
-            ->limit($per_page)
-            ->offset(($page - 1) * $per_page);
-
+            ->limit($st_links);
         $result = $db_slave->query($db_slave->sql());
         while ($item = $result->fetch()) {
-            if ($item['homeimgthumb'] == 1) {
-                //image thumb
-                $item['src'] = NV_BASE_SITEURL . NV_FILES_DIR . '/' . $module_upload . '/' . $item['homeimgfile'];
-            } elseif ($item['homeimgthumb'] == 2) {
-                //image file
-                $item['src'] = NV_BASE_SITEURL . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $item['homeimgfile'];
-            } elseif ($item['homeimgthumb'] == 3) {
-                //image url
-                $item['src'] = $item['homeimgfile'];
-            } elseif (! empty($show_no_image)) {
-                //no image
-                $item['src'] = NV_BASE_SITEURL . $show_no_image;
-            } else {
-                $item['src'] = '';
-            }
-
-            $item['alt'] = ! empty($item['homeimgalt']) ? $item['homeimgalt'] : $item['title'];
-            $item['width'] = $module_config[$module_name]['homewidth'];
-
-            $end_weight = $item['weight'];
-
             $item['link'] = $global_array_cat[$item['catid']]['link'] . '/' . $item['alias'] . '-' . $item['id'] . $global_config['rewrite_exturl'];
-            $item_array[] = $item;
+            $item_array_other[] = $item;
         }
-        $result->closeCursor();
         unset($query, $row);
-
-        $item_array_other = array();
-        if ($st_links > 0) {
-            $db_slave->sqlreset()
-                ->select('t1.id, t1.catid, t1.addtime, t1.edittime, t1.publtime, t1.title, t1.alias, t1.hitstotal, t1.external_link')
-                ->from(NV_PREFIXLANG . '_' . $module_data . '_rows t1')
-                ->join('INNER JOIN ' . NV_PREFIXLANG . '_' . $module_data . '_block t2 ON t1.id = t2.id')
-                ->where('t2.bid= ' . $bid . ' AND t2.weight > ' . $end_weight)
-                ->order('t2.weight ASC')
-                ->limit($st_links);
-            $result = $db_slave->query($db_slave->sql());
-            while ($item = $result->fetch()) {
-                $item['link'] = $global_array_cat[$item['catid']]['link'] . '/' . $item['alias'] . '-' . $item['id'] . $global_config['rewrite_exturl'];
-                $item_array_other[] = $item;
-            }
-            unset($query, $row);
-        }
-
-        $generate_page = nv_alias_page($page_title, $base_url, $num_items, $per_page, $page);
-        if (! empty($image_group)) {
-            $image_group = NV_BASE_SITEURL . NV_FILES_DIR . '/' . $module_upload . '/' . $image_group;
-        }
-        $contents = topic_theme($item_array, $item_array_other, $generate_page, $page_title, $description, $image_group);
     }
+
+    $generate_page = nv_alias_page($page_title, $base_url, $num_items, $per_page, $page);
+    if (!empty($image_group)) {
+        $image_group = NV_BASE_SITEURL . NV_FILES_DIR . '/' . $module_upload . '/' . $image_group;
+    }
+    $contents = topic_theme($item_array, $item_array_other, $generate_page, $page_title, $description, $image_group);
 } else {
+    $page_title = $module_info['funcs']['groups']['func_site_title'];
+    $key_words = $module_info['keywords'];
+    $page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $module_info['alias']['groups'];
+    $base_url_rewrite = nv_url_rewrite($page_url, true);
+    $base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+    if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+        $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+    } elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+        nv_redirect_location($base_url_rewrite_location);
+    } else {
+        $canonicalUrl = $base_url_rewrite;
+    }
+
     $array_cat = array();
     $key = 0;
 
@@ -163,9 +188,6 @@ if (isset($array_op[1])) {
     }
 
     $contents = viewsubcat_main($viewcat, $array_cat);
-
-    $page_title = $module_info['funcs']['groups']['func_site_title'];
-    $key_words = $module_info['keywords'];
 }
 
 include NV_ROOTDIR . '/includes/header.php';

--- a/modules/news/funcs/instant-rss.php
+++ b/modules/news/funcs/instant-rss.php
@@ -36,6 +36,7 @@ $gettime = empty($module_config[$module_name]['instant_articles_gettime']) ? 0 :
 $channel['title'] = $module_info['custom_title'];
 $channel['link'] = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
 $channel['description'] = !empty($module_info['description']) ? $module_info['description'] : $global_config['site_description'];
+$atomlink = NV_BASE_SITEURL . "index.php?" . NV_LANG_VARIABLE . "=" . NV_LANG_DATA . "&amp;" . NV_NAME_VARIABLE . "=" . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $module_info['alias']['rss'];
 
 $catid = 0;
 if (isset($array_op[1])) {
@@ -58,6 +59,7 @@ if (!empty($catid)) {
     $channel['title'] = $module_info['custom_title'] . ' - ' . $global_array_cat[$catid]['title'];
     $channel['link'] = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $alias_cat_url;
     $channel['description'] = $global_array_cat[$catid]['description'];
+    $atomlink .= '/' . $alias_cat_url;
 
     $db_slave->from(NV_PREFIXLANG . '_' . $module_data . '_' . $catid)->where('status=1 AND instant_active=1' . ($gettime ? ' AND (publtime>= ' . $gettime . ' OR edittime >= ' . $gettime . ')' : ''));
 } else {
@@ -132,5 +134,5 @@ if (!defined('NV_IS_MODADMIN') and ($cache = $nv_Cache->getItem($module_name, $c
     }
 }
 
-nv_rss_generate($channel, $items, 'ISO8601');
+nv_rss_generate($channel, $items, $atomlink, 'ISO8601');
 die();

--- a/modules/news/funcs/main.php
+++ b/modules/news/funcs/main.php
@@ -14,10 +14,10 @@ if (!defined('NV_IS_MOD_NEWS')) {
 
 $page_title = $module_info['site_title'];
 $key_words = $module_info['keywords'];
+$page_url = $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
 
 $contents = '';
 $cache_file = '';
-$base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
 $viewcat = $module_config[$module_name]['indexfile'];
 $no_generate = ['viewcat_none', 'viewcat_main_left', 'viewcat_main_right', 'viewcat_main_bottom', 'viewcat_two_column'];
 
@@ -30,7 +30,19 @@ if (($page < 2 and isset($array_op[0])) or isset($array_op[1]) or ($page > 1 and
     nv_redirect_location($base_url);
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($base_url . ($page > 1 ? ('&amp;' . NV_OP_VARIABLE . '=page-' . $page) : ''), true);
+if ($page > 1) {
+    $page_url .= '&amp;' . NV_OP_VARIABLE . '=page-' . $page;
+}
+
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 if (!defined('NV_IS_MODADMIN') and $page < 5) {
     $cache_file = NV_LANG_DATA . '_' . $module_info['template'] . '-' . $op . '-' . $page . '-' . NV_CACHE_PREFIX . '.cache';

--- a/modules/news/funcs/print.php
+++ b/modules/news/funcs/print.php
@@ -37,19 +37,19 @@ if ($id > 0 and $catid > 0) {
     unset($sql, $result, $body_contents);
 
     if ($content['allowed_print'] == 1 and (defined('NV_IS_MODADMIN') or ($content['status'] == 1 and $content['publtime'] < NV_CURRENTTIME and ($content['exptime'] == 0 or $content['exptime'] > NV_CURRENTTIME)))) {
-        $base_url_rewrite = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=print/' . $global_array_cat[$catid]['alias'] . '/' . $content['alias'] . '-' . $id . $global_config['rewrite_exturl'], true);
+        $page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=print/' . $global_array_cat[$catid]['alias'] . '/' . $content['alias'] . '-' . $id . $global_config['rewrite_exturl'];
+        $base_url_rewrite = nv_url_rewrite($page_url, true);
         if ($_SERVER['REQUEST_URI'] != $base_url_rewrite and NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite) {
             nv_redirect_location($base_url_rewrite);
         }
+
+        $base_url_rewrite = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $global_array_cat[$catid]['alias'] . '/' . $content['alias'] . '-' . $id . $global_config['rewrite_exturl'], true);
+        $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
 
         $sql = 'SELECT title FROM ' . NV_PREFIXLANG . '_' . $module_data . '_sources WHERE sourceid = ' . $content['sourceid'];
         $result = $db_slave->query($sql);
         $sourcetext = $result->fetchColumn();
         unset($sql, $result);
-
-        $base_url_rewrite = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $global_array_cat[$catid]['alias'] . '/' . $content['alias'] . '-' . $id . $global_config['rewrite_exturl'], true);
-
-        $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
 
         $meta_tags = nv_html_meta_tags();
 

--- a/modules/news/funcs/rss.php
+++ b/modules/news/funcs/rss.php
@@ -18,6 +18,7 @@ $items = [];
 $channel['title'] = $module_info['custom_title'];
 $channel['link'] = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
 $channel['description'] = !empty($module_info['description']) ? $module_info['description'] : $global_config['site_description'];
+$atomlink = NV_BASE_SITEURL . "index.php?" . NV_LANG_VARIABLE . "=" . NV_LANG_DATA . "&amp;" . NV_NAME_VARIABLE . "=" . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $module_info['alias']['rss'];
 
 $catid = 0;
 if (isset($array_op[1])) {
@@ -40,6 +41,7 @@ if (!empty($catid)) {
     $channel['title'] = $module_info['custom_title'] . ' - ' . $global_array_cat[$catid]['title'];
     $channel['link'] = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $alias_cat_url;
     $channel['description'] = $global_array_cat[$catid]['description'];
+    $atomlink .= '/' . $alias_cat_url;
 
     $db_slave->from(NV_PREFIXLANG . '_' . $module_data . '_' . $catid)->where('status=1');
 } else {
@@ -74,5 +76,5 @@ if ($module_info['rss']) {
         ];
     }
 }
-nv_rss_generate($channel, $items);
+nv_rss_generate($channel, $items, $atomlink);
 die();

--- a/modules/news/funcs/savefile.php
+++ b/modules/news/funcs/savefile.php
@@ -54,19 +54,19 @@ if ($id > 0 and $catid > 0) {
         unset($body_contents);
 
         if ($content['allowed_save'] == 1 and (defined('NV_IS_MODADMIN') or ($content['status'] == 1 and $content['publtime'] < NV_CURRENTTIME and ($content['exptime'] == 0 or $content['exptime'] > NV_CURRENTTIME)))) {
-            $base_url_rewrite = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=savefile/' . $global_array_cat[$catid]['alias'] . '/' . $content['alias'] . '-' . $id . $global_config['rewrite_exturl'], true);
+            $page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=savefile/' . $global_array_cat[$catid]['alias'] . '/' . $content['alias'] . '-' . $id . $global_config['rewrite_exturl'];
+            $base_url_rewrite = nv_url_rewrite($page_url, true);
             if ($_SERVER['REQUEST_URI'] != $base_url_rewrite and NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite) {
                 nv_redirect_location($base_url_rewrite);
             }
+
+            $base_url_rewrite = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $global_array_cat[$catid]['alias'] . '/' . $content['alias'] . '-' . $id . $global_config['rewrite_exturl'], true);
+            $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
 
             $sql = 'SELECT title FROM ' . NV_PREFIXLANG . '_' . $module_data . '_sources WHERE sourceid = ' . $content['sourceid'];
             $result = $db_slave->query($sql);
             $sourcetext = $result->fetchColumn();
             unset($sql, $result);
-
-            $base_url_rewrite = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $global_array_cat[$catid]['alias'] . '/' . $content['alias'] . '-' . $id . $global_config['rewrite_exturl'], true);
-
-            $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
 
             $meta_tags = nv_html_meta_tags();
             $content['bodytext'] = $db_slave->query('SELECT bodyhtml FROM ' . NV_PREFIXLANG . '_' . $module_data . '_detail where id=' . $content['id'])->fetchColumn();

--- a/modules/news/funcs/search.php
+++ b/modules/news/funcs/search.php
@@ -58,46 +58,46 @@ function BoldKeywordInStr($str, $keyword)
 }
 
 $key = $nv_Request->get_title('q', 'get', '');
+$key = str_replace(["'", '"', '<', '>', "&#039;", "&quot;", "&lt;", "&gt;"], '', $key);
 $key = str_replace('+', ' ', $key);
 $key = trim(nv_substr($key, 0, NV_MAX_SEARCH_LENGTH));
 $keyhtml = nv_htmlspecialchars($key);
 
-$base_url_rewrite = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
 if (!empty($key)) {
-    $base_url_rewrite .= '&q=' . urlencode($key);
+    $page_url .= '&q=' . urlencode($key);
 }
 
 $choose = $nv_Request->get_int('choose', 'get', 0);
 if (!empty($choose)) {
-    $base_url_rewrite .= '&choose=' . $choose;
+    $page_url .= '&choose=' . $choose;
 }
 
 $catid = $nv_Request->get_int('catid', 'get', 0);
 if (!empty($catid)) {
-    $base_url_rewrite .= '&catid=' . $catid;
+    $page_url .= '&catid=' . $catid;
 }
 $from_date = $nv_Request->get_title('from_date', 'get', '', 0);
 $date_array['from_date'] = preg_replace('/[^0-9]/', '.', urldecode($from_date));
 if (preg_match('/^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{4})$/', $date_array['from_date'])) {
-    $base_url_rewrite .= '&from_date=' . $date_array['from_date'];
+    $page_url .= '&from_date=' . $date_array['from_date'];
 }
 
 $to_date = $nv_Request->get_title('to_date', 'get', '', 0);
 $date_array['to_date'] = preg_replace('/[^0-9]/', '.', urldecode($to_date));
 if (preg_match('/^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{4})$/', $date_array['to_date'])) {
-    $base_url_rewrite .= '&to_date=' . $date_array['to_date'];
+    $page_url .= '&to_date=' . $date_array['to_date'];
 }
 
 $page = $nv_Request->get_int('page', 'get', 1);
 if ($page > 1) {
-    $base_url_rewrite .= '&page=' . $page;
+    $page_url .= '&page=' . $page;
 }
-$base_url_rewrite = nv_url_rewrite($base_url_rewrite, true);
+$base_url_rewrite = nv_url_rewrite($page_url, true);
 
 $request_uri = $_SERVER['REQUEST_URI'];
 if ($request_uri != $base_url_rewrite and NV_MAIN_DOMAIN . $request_uri != $base_url_rewrite) {
-    header('Location: ' . $base_url_rewrite);
-    die();
+    nv_redirect_location($base_url_rewrite);
 }
 
 $array_cat_search = array();

--- a/modules/news/funcs/sendmail.php
+++ b/modules/news/funcs/sendmail.php
@@ -30,6 +30,16 @@ if ($id > 0 and $catid > 0) {
         $allowed_send = $db_slave->query('SELECT allowed_send FROM ' . NV_PREFIXLANG . '_' . $module_data . '_detail where id=' . $id)->fetchColumn();
         if ($allowed_send == 1) {
             unset($sql, $result);
+
+            $page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=sendmail/' . $global_array_cat[$catid]['alias'] . '/' . $alias . '-' . $id . $global_config['rewrite_exturl'];
+            $base_url_rewrite = nv_url_rewrite($page_url, true);
+            if ($_SERVER['REQUEST_URI'] != $base_url_rewrite and NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite) {
+                nv_redirect_location($base_url_rewrite);
+            }
+
+            $base_url_rewrite = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $global_array_cat[$catid]['alias'] . '/' . $alias . '-' . $id . $global_config['rewrite_exturl'], true);
+            $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+
             $result = '';
             $check = false;
             $checkss = $nv_Request->get_string('checkss', 'post', '');

--- a/modules/news/funcs/tag.php
+++ b/modules/news/funcs/tag.php
@@ -32,9 +32,21 @@ if (!empty($page_title) and $page_title == strip_punctuation($page_title)) {
     list($tid, $image_tag, $description, $key_words) = $stmt->fetch(3);
 
     if ($tid > 0) {
-        $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=tag/' . $alias;
+        $page_url = $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=tag/' . $alias;
         if ($page > 1) {
+            $page_url .= '/page-' . $page;
             $page_title .= NV_TITLEBAR_DEFIS . $lang_global['page'] . ' ' . $page;
+        }
+
+        $base_url_rewrite = nv_url_rewrite($page_url, true);
+        $base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+        $request_uri = rawurldecode($_SERVER['REQUEST_URI']);
+        if ($request_uri == $base_url_rewrite_location) {
+            $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+        } elseif (NV_MAIN_DOMAIN . $request_uri != $base_url_rewrite_location) {
+            nv_redirect_location($base_url_rewrite_location);
+        } else {
+            $canonicalUrl = $base_url_rewrite;
         }
 
         $array_mod_title[] = array(

--- a/modules/news/funcs/topic.php
+++ b/modules/news/funcs/topic.php
@@ -13,6 +13,7 @@ if (!defined('NV_IS_MOD_NEWS')) {
 }
 
 $show_no_image = $module_config[$module_name]['show_no_image'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $module_info['alias']['topic'];
 
 $array_mod_title[] = array(
     'catid' => 0,
@@ -34,15 +35,18 @@ if (!empty($alias)) {
     list ($topicid, $page_title, $alias, $topic_image, $description, $key_words) = $sth->fetch(3);
 
     if ($topicid > 0) {
-        $base_url_rewrite = $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $module_info['alias']['topic'] . '/' . $alias;
+        $page_url .= '/' . $alias;
+        $base_url = $page_url;
+
         if ($page > 1) {
             $page_title .= NV_TITLEBAR_DEFIS . $lang_global['page'] . ' ' . $page;
-            $base_url_rewrite .= '/page-' . $page;
+            $page_url .= '/page-' . $page;
         }
-        $base_url_rewrite = nv_url_rewrite(str_replace('&amp;', '&', $base_url_rewrite), true);
+        $base_url_rewrite = nv_url_rewrite(str_replace('&amp;', '&', $page_url), true);
         if ($_SERVER['REQUEST_URI'] != $base_url_rewrite and NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite) {
             nv_redirect_location($base_url_rewrite);
         }
+        $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
 
         $array_mod_title[] = array(
             'catid' => 0,
@@ -122,6 +126,8 @@ if (!empty($alias)) {
         nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $module_info['alias']['topic']);
     }
 } else {
+    $canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
+
     $page_title = $module_info['funcs'][$op]['func_site_title'];
     $key_words = $module_info['keywords'];
 

--- a/modules/news/funcs/viewcat.php
+++ b/modules/news/funcs/viewcat.php
@@ -16,7 +16,7 @@ $cache_file = '';
 $contents = '';
 $viewcat = $global_array_cat[$catid]['viewcat'];
 $set_view_page = ($page > 1 and substr($viewcat, 0, 13) == 'viewcat_main_') ? true : false;
-$base_url = $global_array_cat[$catid]['link'];
+$page_url = $base_url = $global_array_cat[$catid]['link'];
 $no_generate = ['viewcat_two_column'];
 
 if (!defined('NV_IS_MODADMIN') and $page < 5) {
@@ -32,8 +32,14 @@ if (!defined('NV_IS_MODADMIN') and $page < 5) {
 
 // Kiểm tra và chặn đánh tùy ý các op
 if (($page < 2 and isset($array_op[1])) or isset($array_op[2]) or ($page > 1 and in_array($viewcat, $no_generate))) {
-    nv_redirect_location($base_url);
+    nv_redirect_location($page_url);
 }
+
+$base_url_rewrite = nv_url_rewrite(str_replace('&amp;', '&', $page_url), true);
+if ($_SERVER['REQUEST_URI'] != $base_url_rewrite and NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite) {
+    nv_redirect_location($base_url_rewrite);
+}
+$canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
 
 $page_title = (!empty($global_array_cat[$catid]['titlesite'])) ? $global_array_cat[$catid]['titlesite'] : $global_array_cat[$catid]['title'];
 $key_words = $global_array_cat[$catid]['keywords'];

--- a/modules/news/theme.php
+++ b/modules/news/theme.php
@@ -764,7 +764,6 @@ function detail_theme($news_contents, $array_keyword, $related_new_array, $relat
     $xtpl->assign('NEWSID', $news_contents['id']);
     $xtpl->assign('NEWSCHECKSS', $news_contents['newscheckss']);
     $xtpl->assign('DETAIL', $news_contents);
-    $xtpl->assign('SELFURL', $client_info['selfurl']);
 
     if ($news_contents['allowed_send'] == 1) {
         $xtpl->assign('URL_SENDMAIL', $news_contents['url_sendmail']);

--- a/modules/page/funcs/main.php
+++ b/modules/page/funcs/main.php
@@ -12,7 +12,19 @@ if (!defined('NV_IS_MOD_PAGE')) {
     die('Stop!!!');
 }
 
+$page_url = $base_url;
+
 if ($page_config['viewtype'] == 2) {
+    $base_url_rewrite = nv_url_rewrite($page_url, true);
+    $base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+    if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+        $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+    } elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+        nv_redirect_location($base_url_rewrite_location);
+    } else {
+        $canonicalUrl = $base_url_rewrite;
+    }
+    
     $page_title = $module_info['site_title'];
     $key_words = $module_info['keywords'];
     $mod_title = isset($lang_module['main_title']) ? $lang_module['main_title'] : $module_info['custom_title'];
@@ -20,14 +32,19 @@ if ($page_config['viewtype'] == 2) {
 
     // Không cho đánh op khi không hiển thị nội dung
     if (isset($array_op[0])) {
-        nv_redirect_location($base_url);
+        nv_redirect_location($page_url);
     }
 } elseif ($id) {
     // Xem theo bài viết
-    $base_url_rewrite = nv_url_rewrite($base_url . '&amp;' . NV_OP_VARIABLE . '=' . $rowdetail['alias'] . $global_config['rewrite_exturl'], true);
-    $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
-    if (strpos($_SERVER['REQUEST_URI'], $base_url_check) !== 0 and strpos(NV_MY_DOMAIN . $_SERVER['REQUEST_URI'], $base_url_check) !== 0) {
-        nv_redirect_location($base_url_rewrite);
+    $page_url .= '&amp;' . NV_OP_VARIABLE . '=' . $rowdetail['alias'] . $global_config['rewrite_exturl'];
+    $base_url_rewrite = nv_url_rewrite($page_url, true);
+    $base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+    if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+        $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+    } elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+        nv_redirect_location($base_url_rewrite_location);
+    } else {
+        $canonicalUrl = $base_url_rewrite;
     }
 
     if (!empty($rowdetail['image']) and !nv_is_url($rowdetail['image'])) {
@@ -41,7 +58,7 @@ if ($page_config['viewtype'] == 2) {
     $rowdetail['number_edit_time'] = $rowdetail['edit_time'] ? $rowdetail['edit_time'] : $rowdetail['add_time'];
     $rowdetail['add_time'] = nv_date('H:i T l, d/m/Y', $rowdetail['add_time']);
     $rowdetail['edit_time'] = nv_date('H:i T l, d/m/Y', $rowdetail['edit_time']);
-    $rowdetail['link'] = $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+    $rowdetail['link'] = $canonicalUrl;
 
     $module_info['layout_funcs'][$op_file] = !empty($rowdetail['layout_func']) ? $rowdetail['layout_func'] : $module_info['layout_funcs'][$op_file];
 
@@ -106,6 +123,19 @@ if ($page_config['viewtype'] == 2) {
     $contents = nv_page_main($rowdetail, $other_links, $content_comment);
 } else {
     // Xem theo danh sách
+    if ($page > 1) {
+        $page_url .= '&amp;' . NV_OP_VARIABLE . '=page-' . $page;
+    }
+    $base_url_rewrite = nv_url_rewrite($page_url, true);
+    $base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+    if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+        $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+    } elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+        nv_redirect_location($base_url_rewrite_location);
+    } else {
+        $canonicalUrl = $base_url_rewrite;
+    }
+
     $page_title = $module_info['site_title'];
     $key_words = $module_info['keywords'];
     $mod_title = isset($lang_module['main_title']) ? $lang_module['main_title'] : $module_info['custom_title'];

--- a/modules/page/funcs/rss.php
+++ b/modules/page/funcs/rss.php
@@ -18,6 +18,7 @@ $items = [];
 $channel['title'] = $module_info['custom_title'];
 $channel['link'] = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
 $channel['description'] = !empty($module_info['description']) ? $module_info['description'] : $global_config['site_description'];
+$atomlink = NV_BASE_SITEURL . "index.php?" . NV_LANG_VARIABLE . "=" . NV_LANG_DATA . "&amp;" . NV_NAME_VARIABLE . "=" . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $module_info['alias']['rss'];
 
 if ($module_info['rss']) {
     $sql = 'SELECT id, title, alias, image, imagealt, description, add_time FROM ' . NV_PREFIXLANG . '_' . $module_data . ' WHERE status=1 ORDER BY weight ASC LIMIT 20';
@@ -34,5 +35,5 @@ if ($module_info['rss']) {
         ];
     }
 }
-nv_rss_generate($channel, $items);
+nv_rss_generate($channel, $items, $atomlink);
 die();

--- a/modules/page/theme.php
+++ b/modules/page/theme.php
@@ -52,7 +52,6 @@ function nv_page_main($row, $ab_links, $content_comment)
             $meta_property['fb:app_id'] = $page_config['facebookapi'];
             $meta_property['og:locale'] = (NV_LANG_DATA == 'vi') ? 'vi_VN' : 'en_US';
 
-            $xtpl->assign('SELFURL', $client_info['selfurl']);
             $xtpl->parse('main.socialbutton.facebook');
         }
 

--- a/modules/statistics/funcs/allbots.php
+++ b/modules/statistics/funcs/allbots.php
@@ -15,6 +15,16 @@ if (! defined('NV_IS_MOD_STATISTICS')) {
 $page_title = $lang_module['bot'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['bot'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 $result = $db->query("SELECT COUNT(*), MAX(c_count) FROM " . NV_COUNTER_GLOBALTABLE . " WHERE c_type='bot' AND c_count!=0");
 list($num_items, $max) = $result->fetch(3);

--- a/modules/statistics/funcs/allbrowsers.php
+++ b/modules/statistics/funcs/allbrowsers.php
@@ -15,6 +15,16 @@ if (! defined('NV_IS_MOD_STATISTICS')) {
 $page_title = $lang_module['browser'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['browser'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 $sql = "SELECT COUNT(*), MAX(c_count) FROM " . NV_COUNTER_GLOBALTABLE . " WHERE c_type='browser' AND c_count!=0";
 $result = $db->query($sql);

--- a/modules/statistics/funcs/allcountries.php
+++ b/modules/statistics/funcs/allcountries.php
@@ -15,6 +15,16 @@ if (! defined('NV_IS_MOD_STATISTICS')) {
 $page_title = $lang_module['country'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['country'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 $sql = "SELECT COUNT(*), MAX(c_count) FROM " . NV_COUNTER_GLOBALTABLE . " WHERE c_type='country' AND c_count!=0";
 $result = $db->query($sql);

--- a/modules/statistics/funcs/allos.php
+++ b/modules/statistics/funcs/allos.php
@@ -15,6 +15,16 @@ if (! defined('NV_IS_MOD_STATISTICS')) {
 $page_title = $lang_module['os'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['os'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 $sql = "SELECT COUNT(*), MAX(c_count) FROM " . NV_COUNTER_GLOBALTABLE . " WHERE c_type='os' AND c_count!=0";
 $result = $db->query($sql);

--- a/modules/statistics/funcs/allreferers.php
+++ b/modules/statistics/funcs/allreferers.php
@@ -15,6 +15,16 @@ if (! defined('NV_IS_MOD_STATISTICS')) {
 $page_title = $lang_module['referer'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['referer'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 $sql = 'SELECT COUNT(*), SUM(total), MAX(total) FROM ' . NV_REFSTAT_TABLE;
 $result = $db->query($sql);

--- a/modules/statistics/funcs/main.php
+++ b/modules/statistics/funcs/main.php
@@ -15,6 +15,16 @@ if (!defined('NV_IS_MOD_STATISTICS')) {
 $page_title = $module_info['site_title'];
 $key_words = $module_info['keywords'];
 $mod_title = isset($lang_module['main_title']) ? $lang_module['main_title'] : $module_info['custom_title'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 $current_month_num = date('n', NV_CURRENTTIME);
 $current_year = date('Y', NV_CURRENTTIME);

--- a/modules/statistics/funcs/referer.php
+++ b/modules/statistics/funcs/referer.php
@@ -30,6 +30,16 @@ if (empty($row)) {
 $contents = '';
 $mod_title = $page_title = sprintf($lang_module['refererbysite'], $host);
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op . '&host=' . $host;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 $cts = array();
 $cts['caption'] = $page_title;

--- a/modules/two-step-verification/funcs/confirm.php
+++ b/modules/two-step-verification/funcs/confirm.php
@@ -14,10 +14,14 @@ if (!defined('NV_MOD_2STEP_VERIFICATION')) {
 
 $page_title = $module_info['site_title'];
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
 
 $nv_redirect = '';
 if ($nv_Request->isset_request('nv_redirect', 'post,get')) {
     $nv_redirect = nv_get_redirect();
+    if ($nv_Request->isset_request('nv_redirect', 'get') and !empty($nv_redirect)) {
+        $page_url .= '&amp;nv_redirect=' . $nv_redirect;
+    }
 }
 
 /**
@@ -87,6 +91,16 @@ if ($tokend_confirm_password != $tokend) {
         header('Location: ' . nv_redirect_decrypt($nv_redirect));
         die();
     }
+}
+
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
 }
 
 include NV_ROOTDIR . '/includes/header.php';

--- a/modules/two-step-verification/funcs/main.php
+++ b/modules/two-step-verification/funcs/main.php
@@ -14,6 +14,7 @@ if (!defined('NV_MOD_2STEP_VERIFICATION')) {
 
 $page_title = $module_info['site_title'];
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name;
 
 // Tự động chuyển đến trang thiết lập nếu hệ thống bắt buộc xác thực ở quản trị, hoặc tất cả các khu vực
 if (empty($user_info['active2step']) and in_array($global_config['two_step_verification'], [1, 3])) {
@@ -68,6 +69,16 @@ $autoshowcode = false;
 if ($nv_Request->isset_request('showcode_' . $module_data, 'session')) {
     $autoshowcode = true;
     $nv_Request->unset_request('showcode_' . $module_data, 'session');
+}
+
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
 }
 
 $contents = nv_theme_info_2step($backupcodes, $autoshowcode);

--- a/modules/two-step-verification/funcs/setup.php
+++ b/modules/two-step-verification/funcs/setup.php
@@ -18,10 +18,14 @@ if (!empty($user_info['active2step'])) {
 
 $page_title = $module_info['site_title'];
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
 
 $nv_redirect = '';
 if ($nv_Request->isset_request('nv_redirect', 'post,get')) {
     $nv_redirect = nv_get_redirect();
+    if ($nv_Request->isset_request('nv_redirect', 'get') and !empty($nv_redirect)) {
+        $page_url .= '&amp;nv_redirect=' . $nv_redirect;
+    }
 }
 
 /**
@@ -85,6 +89,16 @@ if ($checkss == NV_CHECK_SESSION) {
         'input' => '',
         'mess' => ''
     ));
+}
+
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
 }
 
 $contents = nv_theme_config_2step($secretkey, $nv_redirect);

--- a/modules/users/funcs/active.php
+++ b/modules/users/funcs/active.php
@@ -39,6 +39,8 @@ if (empty($row)) {
 
 $page_title = $mod_title = $lang_module['register'];
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 $check_update_user = false;
 $is_change_email = false;

--- a/modules/users/funcs/avatar.php
+++ b/modules/users/funcs/avatar.php
@@ -90,6 +90,8 @@ function deleteAvatar()
 }
 
 $page_title = $lang_module['avatar_pagetitle'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 $array = array();
 $array['success'] = 0;

--- a/modules/users/funcs/editinfo.php
+++ b/modules/users/funcs/editinfo.php
@@ -1025,6 +1025,8 @@ if ($checkss == $array_data['checkss'] and $array_data['type'] == 'basic') {
 
 $page_title = $mod_title = $lang_module['editinfo_pagetitle'];
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 if (!defined('NV_EDITOR')) {
     define('NV_EDITOR', 'ckeditor');

--- a/modules/users/funcs/groups.php
+++ b/modules/users/funcs/groups.php
@@ -13,6 +13,9 @@ if (! defined('NV_IS_MOD_USER')) {
 }
 
 $page_title = $lang_module['group_manage'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
+
 $contents = '';
 
 // Lay danh sach nhom

--- a/modules/users/funcs/login.php
+++ b/modules/users/funcs/login.php
@@ -828,6 +828,8 @@ if ($nv_Request->get_int('nv_ajax', 'post', 0) == 1) {
 $page_title = $lang_module['login'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['login'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 $contents = user_login();
 

--- a/modules/users/funcs/logout.php
+++ b/modules/users/funcs/logout.php
@@ -49,6 +49,8 @@ if ($nv_ajax_login) {
 $page_title = $module_info['site_title'];
 $key_words = $module_info['keywords'];
 $mod_title = isset($lang_module['main_title']) ? $lang_module['main_title'] : $module_info['custom_title'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 $info = $lang_module['logout_ok'] . '<br /><br />';
 $info .= '<img border="0" src="' . NV_BASE_SITEURL . NV_ASSETS_DIR . '/images/load_bar.gif"><br /><br />';

--- a/modules/users/funcs/lostactivelink.php
+++ b/modules/users/funcs/lostactivelink.php
@@ -27,6 +27,8 @@ if ($global_config['allowuserreg'] != 2) {
 
 $page_title = $mod_title = $lang_module['lostpass_page_title'];
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 $data = [];
 $data['checkss'] = md5(NV_CHECK_SESSION . '_' . $module_name . '_' . $op);

--- a/modules/users/funcs/lostpass.php
+++ b/modules/users/funcs/lostpass.php
@@ -312,6 +312,8 @@ if ($mailer_mode != 'smtp' and defined('NV_REGISTER_DOMAIN') and $global_config[
 
 $page_title = $mod_title = $lang_module['lostpass_page_title'];
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 $contents = user_lostpass($data);
 

--- a/modules/users/funcs/main.php
+++ b/modules/users/funcs/main.php
@@ -18,23 +18,34 @@ if (isset($array_op[0])) {
 $page_title = $module_info['site_title'];
 $key_words = $module_info['keywords'];
 $mod_title = isset($lang_module['main_title']) ? $lang_module['main_title'] : $module_info['custom_title'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name;
 
 if (!defined('NV_IS_ADMIN') and !$global_config['allowuserlogin']) {
     $contents = user_info_exit($lang_module['notallowuserlogin']);
 } else {
     if (!defined('NV_IS_USER')) {
-        $url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=login';
+        $page_url .= '&' . NV_OP_VARIABLE . '=login';
         $nv_redirect = nv_get_redirect();
         if (!empty($nv_redirect)) {
-            $url .= '&nv_redirect=' . $nv_redirect;
+            $page_url .= '&nv_redirect=' . $nv_redirect;
         }
-        nv_redirect_location($url);
+        nv_redirect_location($page_url);
     } else {
         // So nhom dang quan ly
         $user_info['group_manage'] = $db->query('SELECT COUNT(*) FROM ' . NV_MOD_TABLE . '_groups_users WHERE userid=' . $user_info['userid'] . ' AND is_leader=1')->fetchColumn();
 
         $contents = user_welcome();
     }
+}
+
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
 }
 
 include NV_ROOTDIR . '/includes/header.php';

--- a/modules/users/funcs/memberlist.php
+++ b/modules/users/funcs/memberlist.php
@@ -15,6 +15,7 @@ if (! defined('NV_IS_MOD_USER')) {
 $page_title = $module_info['funcs'][$op]['func_site_title'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['listusers'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
 
 if (!nv_user_in_groups($global_config['whoviewuser'])) {
     header('Location: ' . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name));
@@ -35,6 +36,9 @@ if (isset($array_op[1]) and ! empty($array_op[1])) {
     if (preg_match('/^(.*)\-([a-z0-9]{32})$/', $array_op[1], $matches)) {
         $md5 = $matches[2];
     }
+
+    $page_url .= '/' . $array_op[1];
+    $canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
     if (! empty($md5)) {
         $stmt = $db->prepare('SELECT * FROM ' . NV_MOD_TABLE . ' WHERE md5username = :md5' . (defined('NV_IS_ADMIN') ? '' : ' AND active=1'));
@@ -125,12 +129,14 @@ if (isset($array_op[1]) and ! empty($array_op[1])) {
     $sortby = $nv_Request->get_string('sortby', 'get', 'DESC');
     $page = $nv_Request->get_int('page', 'get', 1);
 
+    $page_url .= '&orderby=' . $orderby . '&sortby=' . $sortby;
+
     // Kiem tra du lieu hop chuan
     if ((! empty($orderby) and ! in_array($orderby, array( 'username', 'gender', 'regdate' ))) or (! empty($sortby) and ! in_array($sortby, array( 'DESC', 'ASC' )))) {
         nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name);
     }
 
-    $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $op . '&orderby=' . $orderby . '&sortby=' . $sortby;
+    $base_url = $page_url;
 
     $per_page = 25;
     $array_order = array(
@@ -193,6 +199,7 @@ if (isset($array_op[1]) and ! empty($array_op[1])) {
     // Tieu de khi phan trang
     if ($page > 1) {
         $page_title .= NV_TITLEBAR_DEFIS . sprintf($lang_module['page'], ceil($page / $per_page));
+        $page_url .= '&page=' . $page;
     }
 
     $generate_page = nv_generate_page($base_url, $num_items, $per_page, $page);
@@ -200,6 +207,8 @@ if (isset($array_op[1]) and ! empty($array_op[1])) {
     unset($result, $item);
 
     $contents = nv_memberslist_theme($users_array, $array_order_new, $generate_page);
+
+    $canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 }
 
 include NV_ROOTDIR . '/includes/header.php';

--- a/modules/users/funcs/register.php
+++ b/modules/users/funcs/register.php
@@ -17,6 +17,9 @@ if (defined('NV_IS_USER') and !defined('ACCESS_ADDUS')) {
     nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name);
 }
 
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
+
 // Ngung dang ki thanh vien
 if (!$global_config['allowuserreg']) {
     $page_title = $lang_module['register'];

--- a/themes/default/blocks/global.QR_code.php
+++ b/themes/default/blocks/global.QR_code.php
@@ -105,7 +105,7 @@ if (!nv_function_exists('nv_block_qr_code')) {
      */
     function nv_block_qr_code($block_config)
     {
-        global $page_title, $global_config, $client_info, $lang_global;
+        global $page_title, $global_config, $page_url, $module_name, $home, $op, $lang_global;
 
         if (file_exists(NV_ROOTDIR . '/themes/' . $global_config['module_theme'] . '/blocks/global.QR_code.tpl')) {
             $block_theme = $global_config['module_theme'];
@@ -119,7 +119,20 @@ if (!nv_function_exists('nv_block_qr_code')) {
         $xtpl->assign('LANG', $lang_global);
         $xtpl->assign('NV_BASE_SITEURL', NV_BASE_SITEURL);
 
-        $block_config['selfurl'] = $client_info['selfurl'];
+        if (empty($page_url)) {
+            if ($home) {
+                $current_page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA;
+            } else {
+                $current_page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
+                if ($op != 'main') {
+                    $current_page_url .= '&amp;' . NV_OP_VARIABLE . '=' . $op;
+                }
+            }
+        } else {
+            $current_page_url = $page_url;
+        }
+
+        $block_config['selfurl'] = NV_MAIN_DOMAIN . nv_url_rewrite($current_page_url, true);
         $block_config['title'] = "QR-Code: " . str_replace('"', "&quot;", ($page_title ? $page_title : $global_config['site_name']));
         $xtpl->assign('QRCODE', $block_config);
 

--- a/themes/default/modules/news/detail.tpl
+++ b/themes/default/modules/news/detail.tpl
@@ -200,7 +200,7 @@
 <div class="news_column panel panel-default">
     <div class="panel-body">
         <div class="socialicon clearfix">
-            <div class="fb-like" data-href="{SELFURL}" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true">&nbsp;</div>
+            <div class="fb-like" data-href="{DETAIL.link}" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true">&nbsp;</div>
             <a href="http://twitter.com/share" class="twitter-share-button">Tweet</a>
         </div>
      </div>

--- a/themes/default/modules/page/main.tpl
+++ b/themes/default/modules/page/main.tpl
@@ -24,7 +24,7 @@
         <div class="well well-sm">
             <ul class="nv-social-share">
                 <li class="facebook">
-                    <div class="fb-like" data-href="{SELFURL}" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true">&nbsp;</div>
+                    <div class="fb-like" data-href="{CONTENT.link}" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true">&nbsp;</div>
                 </li>
                 <li>
                     <a href="http://twitter.com/share" class="twitter-share-button">Tweet</a>

--- a/themes/mobile_default/blocks/global.QR_code.php
+++ b/themes/mobile_default/blocks/global.QR_code.php
@@ -105,7 +105,7 @@ if (!nv_function_exists('nv_block_qr_code')) {
      */
     function nv_block_qr_code($block_config)
     {
-        global $page_title, $global_config, $client_info, $lang_global;
+        global $page_title, $global_config, $page_url, $module_name, $home, $op, $lang_global;
 
         if (file_exists(NV_ROOTDIR . '/themes/' . $global_config['module_theme'] . '/blocks/global.QR_code.tpl')) {
             $block_theme = $global_config['module_theme'];
@@ -119,7 +119,20 @@ if (!nv_function_exists('nv_block_qr_code')) {
         $xtpl->assign('LANG', $lang_global);
         $xtpl->assign('NV_BASE_SITEURL', NV_BASE_SITEURL);
 
-        $block_config['selfurl'] = $client_info['selfurl'];
+        if (empty($page_url)) {
+            if ($home) {
+                $current_page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA;
+            } else {
+                $current_page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
+                if ($op != 'main') {
+                    $current_page_url .= '&amp;' . NV_OP_VARIABLE . '=' . $op;
+                }
+            }
+        } else {
+            $current_page_url = $page_url;
+        }
+
+        $block_config['selfurl'] = NV_MAIN_DOMAIN . nv_url_rewrite($current_page_url, true);
         $block_config['title'] = "QR-Code: " . str_replace('"', "&quot;", ($page_title ? $page_title : $global_config['site_name']));
         $xtpl->assign('QRCODE', $block_config);
 

--- a/themes/mobile_default/modules/news/detail.tpl
+++ b/themes/mobile_default/modules/news/detail.tpl
@@ -118,7 +118,7 @@
         <hr />
         <!-- BEGIN: socialbutton -->
         <div class="socialicon pull-left">
-            <div class="fb-like" data-href="{SELFURL}" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true">&nbsp;</div>
+            <div class="fb-like" data-href="{DETAIL.link}" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true">&nbsp;</div>
             <a href="http://twitter.com/share" class="twitter-share-button">Tweet</a>
         </div>
         <!-- END: socialbutton -->

--- a/themes/mobile_default/modules/news/theme.php
+++ b/themes/mobile_default/modules/news/theme.php
@@ -611,7 +611,6 @@ function detail_theme($news_contents, $array_keyword, $related_new_array, $relat
     $xtpl->assign('NEWSID', $news_contents['id']);
     $xtpl->assign('NEWSCHECKSS', $news_contents['newscheckss']);
     $xtpl->assign('DETAIL', $news_contents);
-    $xtpl->assign('SELFURL', $client_info['selfurl']);
 
     if ($news_contents['allowed_send'] == 1) {
         $xtpl->assign('URL_SENDMAIL', $news_contents['url_sendmail']);


### PR DESCRIPTION
Lỗi Cross-site Scripting (XSS) tiềm ẩn
Theo thông báo của acunetix.com, tất cả các website sử dụng NukeViet đang mắc lỗi bảo mật Cross-site Scripting (XSS) (XSS xảy ra khi một ứng dụng web sử dụng dữ liệu đầu vào của người dùng chưa được xác thực hoặc chưa được mã hóa trong đầu ra mà nó tạo ra).
Acunetix.com đưa ra dẫn chứng là:
```html
http://nukeviet.site/Ban-tin-noi-bo/hay-tro-thanh-nha-cung-cap-dich-vu-cua-nukeviet-6.html?%F6"onmouseover=iIbe(99255)//
```
và:
```html
http://nukeviet.site/en/news/?wvstest=javascript:domxssExecutionSink(1,"'\"><xsstag>()locxss")?javascript:domxssExecutionSink(1,"'\"><xsstag>()locxss")#javascript:domxssExecutionSink(1,"'\"><xsstag>()locxss")
```
Khi view source của trang, đoạn mã được chèn vào có tồn tại, nhưng các ký tự đặc biệt của nó đã bị mã hóa, mất khả năng thực thi. Theo đánh giá của chúng tôi, cách chèn mã độc kiểu này hoàn toàn bị vô hiệu ở NukeViet.
Nhưng ở đây cho thấy nguy cơ tiềm ẩn sau: Biến $client_info['selfurl'] bê nguyên giá trị của GET (dòng địa chỉ của trình duyệt), mã hóa các ký tự đặc biệt và cho ra kết quả để hiển thị trong phần HTML-output. Như vậy chúng ta không thể kiểm soát được nội dung của biến $client_info['selfurl'] có hợp lệ hay không. Nếu không khắc phục vấn đề này, $client_info['selfurl'] sẽ là mảnh đất màu mỡ để các hacker đào sâu sau này.

**Hướng khắc phục:**
Chỗ nào có $client_info['selfurl'] được lấy để hiển thị ra bên ngoài - chỗ đó cần thay bằng URL có kiểm duyệt.
Ví dụ:
Trong file modules/News/theme.php, dòng 767:
```php
$xtpl->assign('SELFURL', $client_info['selfurl']);
```
Cần thay là:
```html
$xtpl->assign('SELFURL', $news_contents['link']);
```
Trong đó $news_contents['link'] là URL chuẩn đến trang đang xử lý chứ không phải là URL do người dùng tự nhập.

**function nv_rss_generate($channel, $items)**
Function này hiện đang gán cho biến $atomlink giá trị là $client_info['selfurl'].
Cách fix:
Trong nhân hệ thống đã thay đổi function này với 3 đối số bắt buộc: $channel, $items, $atomlink.
Chỗ nào gọi hàm nv_rss_generate($channel, $items) chỗ đó cần thay bằng:
```php
$atomlink = NV_BASE_SITEURL . "index.php?" . NV_LANG_VARIABLE . "=" . NV_LANG_DATA . "&amp;" . NV_NAME_VARIABLE . "=" . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $module_info['alias']['rss'];
nv_rss_generate($channel, $items, $atomlink);
```

**funtion nv_html_meta_tags**
Trong function này cũng dùng $client_info['selfurl'] để gán cho biến $site_description khi nó rỗng.
Để tránh việc dùng $client_info['selfurl'] không qua kiểm duyệt, thêm vào biến $page_url được định nghĩa ở từng trang của module với giá trị chính là đường dẫn tuyệt đối từ thư mục gốc đến trang đang xử lý.
Ví dụ:
```php
$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $op;
```
Lúc đó, biến $canonicalUrl sẽ được xác định là:
```php
$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
```