### PR TITLE
Potential Cross-site Scripting (XSS) Errors

### DIFF
--- a/includes/core/theme_functions.php
+++ b/includes/core/theme_functions.php
@@ -369,13 +369,16 @@ function nv_xmlOutput($content, $lastModified)
 }
 
 /**
- *
- * @param array $channel
- * @param array $items
+ * nv_rss_generate()
+ * 
+ * @param mixed $channel
+ * @param mixed $items
+ * @param mixed $atomlink
  * @param string $timemode
- * @param boolean $noindex
+ * @param bool $noindex
+ * @return void
  */
-function nv_rss_generate($channel, $items, $timemode = 'GMT', $noindex = true)
+function nv_rss_generate($channel, $items, $atomlink, $timemode = 'GMT', $noindex = true)
 {
     global $global_config, $client_info;
 
@@ -387,7 +390,7 @@ function nv_rss_generate($channel, $items, $timemode = 'GMT', $noindex = true)
 
     $channel['generator'] = 'NukeViet v4.0';
     $channel['title'] = nv_htmlspecialchars($channel['title']);
-    $channel['atomlink'] = str_replace('&', '&amp;', $client_info['selfurl']);
+    $channel['atomlink'] = NV_MY_DOMAIN . nv_url_rewrite($atomlink, true);
     $channel['lang'] = $global_config['site_lang'];
     $channel['copyright'] = $global_config['site_name'];
 
@@ -402,14 +405,6 @@ function nv_rss_generate($channel, $items, $timemode = 'GMT', $noindex = true)
     $channel['link'] = nv_url_rewrite($channel['link'], true);
     if (!str_starts_with($channel['link'], NV_MY_DOMAIN)) {
         $channel['link'] = NV_MY_DOMAIN . $channel['link'];
-    }
-
-    if (preg_match('/^' . nv_preg_quote(NV_MY_DOMAIN . NV_BASE_SITEURL) . '(.+)$/', $channel['atomlink'], $matches)) {
-        $channel['atomlink'] = NV_BASE_SITEURL . $matches[1];
-    }
-    $channel['atomlink'] = nv_url_rewrite($channel['atomlink'], true);
-    if (!str_starts_with($channel['atomlink'], NV_MY_DOMAIN)) {
-        $channel['atomlink'] = NV_MY_DOMAIN . $channel['atomlink'];
     }
 
     $channel['pubDate'] = 0;

--- a/includes/core/user_functions.php
+++ b/includes/core/user_functions.php
@@ -264,9 +264,25 @@ function nv_blocks_content($sitecontent)
  */
 function nv_html_meta_tags($html = true)
 {
-    global $global_config, $lang_global, $key_words, $description, $module_info, $home, $client_info, $op, $page_title, $canonicalUrl, $meta_property, $nv_BotManager;
+    global $global_config, $lang_global, $key_words, $description, $module_name, $module_info, $home, $op, $page_title, $page_url, $meta_property, $nv_BotManager;
 
     $return = [];
+
+    if (empty($site_description) or ($global_config['metaTagsOgp'] and empty($meta_property['og:url']))) {
+        if (empty($page_url)) {
+            if ($home) {
+                $current_page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA;
+            } else {
+                $current_page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
+                if ($op != 'main') {
+                    $current_page_url .= '&amp;' . NV_OP_VARIABLE . '=' . $op;
+                }
+            }
+        } else {
+            $current_page_url = $page_url;
+        }
+        $current_page_url = NV_MAIN_DOMAIN . nv_url_rewrite($current_page_url, true);
+    }
 
     // Tại trang chủ lấy mô tả của site thay vì mô tả của module chọn làm trang chủ
     $site_description = $home ? $global_config['site_description'] : (!empty($description) ? $description : (empty($module_info['description']) ? '' : $module_info['description']));
@@ -280,7 +296,7 @@ function nv_html_meta_tags($html = true)
             $ds[] = $module_info['funcs'][$op]['func_custom_name'];
         }
         $ds[] = $module_info['custom_title'];
-        $ds[] = $client_info['selfurl'];
+        $ds[] = $current_page_url;
         $site_description = implode(' - ', $ds);
     } elseif ($site_description == 'no') {
         $site_description = '';
@@ -427,15 +443,7 @@ function nv_html_meta_tags($html = true)
             $meta_property['og:type'] = 'website';
         }
         if (empty($meta_property['og:url'])) {
-            $ogUrl = !empty($canonicalUrl) ? $canonicalUrl : $client_info['selfurl'];
-            $ogUrl = str_replace(NV_MY_DOMAIN . '/', NV_MAIN_DOMAIN . '/', $ogUrl);
-            if (substr($ogUrl, 0, 4) != 'http') {
-                if (substr($ogUrl, 0, 1) != '/') {
-                    $ogUrl = NV_BASE_SITEURL . $ogUrl;
-                }
-                $ogUrl = NV_MAIN_DOMAIN . $ogUrl;
-            }
-            $meta_property['og:url'] = $ogUrl;
+            $meta_property['og:url'] = $current_page_url;
         }
         if (empty($meta_property['og:image']) and !empty($global_config['ogp_image'])) {
             $imagesize = @getimagesize(NV_ROOTDIR . '/' . $global_config['ogp_image']);

--- a/includes/mainfile.php
+++ b/includes/mainfile.php
@@ -23,7 +23,7 @@ define('NV_CURRENTTIME', isset($_SERVER['REQUEST_TIME']) ? $_SERVER['REQUEST_TIM
 
 // Khong cho xac dinh tu do cac variables
 $db_config = $global_config = $module_config = $client_info = $user_info = $admin_info = $sys_info = $lang_global = $lang_module = $rss = $nv_vertical_menu = $array_mod_title = $content_type = $submenu = $error_info = $countries = $loadScript = $headers = $theme_config = [];
-$page_title = $key_words = $canonicalUrl = $prevPage = $nextPage = $mod_title = $editor_password = $my_head = $my_footer = $description = $contents = '';
+$page_title = $key_words = $page_url = $canonicalUrl = $prevPage = $nextPage = $mod_title = $editor_password = $my_head = $my_footer = $description = $contents = '';
 $editor = false;
 
 // Ket noi voi cac file constants, config

--- a/modules/banners/funcs/addads.php
+++ b/modules/banners/funcs/addads.php
@@ -12,8 +12,17 @@ if (!defined('NV_IS_MOD_BANNERS')) {
     die('Stop!!!');
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op, true);
 $page_title = $module_info['site_title'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 if (!defined('NV_IS_BANNER_CLIENT')) {
     nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name);

--- a/modules/banners/funcs/main.php
+++ b/modules/banners/funcs/main.php
@@ -27,8 +27,18 @@ foreach ($global_array_plans as $row) {
     $contents['rows'][$row['id']]['allowed'] = isset($global_array_uplans[$row['id']]) ? true : false;
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name, true);
 $page_title = $module_info['site_title'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
+
 $contents = nv_banner_theme_main($contents, $manament);
 
 include NV_ROOTDIR . '/includes/header.php';

--- a/modules/banners/funcs/stats.php
+++ b/modules/banners/funcs/stats.php
@@ -12,8 +12,17 @@ if (!defined('NV_IS_MOD_BANNERS')) {
     die('Stop!!!');
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op, true);
 $page_title = $lang_module['stats_views'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 if (!defined('NV_IS_BANNER_CLIENT')) {
     nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name);

--- a/modules/comment/blocks/global.block_facebook_comment_box.php
+++ b/modules/comment/blocks/global.block_facebook_comment_box.php
@@ -83,7 +83,7 @@ if (!nv_function_exists('nv_facebook_comment_box_blocks')) {
      */
     function nv_facebook_comment_box_blocks($block_config)
     {
-        global $client_info, $module_name;
+        global $page_url, $module_name;
         $content = '';
         if (!defined('FACEBOOK_JSSDK')) {
             $lang = (NV_LANG_DATA == 'vi') ? 'vi_VN' : 'en_US';
@@ -101,7 +101,8 @@ if (!nv_function_exists('nv_facebook_comment_box_blocks')) {
 			</script>";
             define('FACEBOOK_JSSDK', true);
         }
-        $content .= '<div class="fb-comments" data-href="' . $client_info['selfurl'] . '" data-num-posts="' . $block_config['numpost'] . '" data-width="' . $block_config['width'] . '" data-colorscheme="' . $block_config['scheme'] . '"></div>';
+        $href = !empty($page_url) ? NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true) : '';
+        $content .= '<div class="fb-comments" data-href="' . $href . '" data-num-posts="' . $block_config['numpost'] . '" data-width="' . $block_config['width'] . '" data-colorscheme="' . $block_config['scheme'] . '"></div>';
 
         return $content;
     }

--- a/modules/contact/funcs/main.php
+++ b/modules/contact/funcs/main.php
@@ -274,25 +274,23 @@ $key_words = $module_info['keywords'];
 $mod_title = isset($lang_module['main_title']) ? $lang_module['main_title'] : $module_info['custom_title'];
 
 $full_theme = true;
-$canonicalUrl = $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
 if (!empty($alias_department)) {
-    $base_url .= '&amp;' . NV_OP_VARIABLE . '=' . $alias_department;
-    $canonicalUrl = $base_url;
-    if (isset($array_op[1]) and $array_op[1] == '0') {
-        $base_url .= '/0';
+    $page_url .= '&amp;' . NV_OP_VARIABLE . '=' . $alias_department;
+    if (isset($array_op[1]) and $array_op[1] === '0') {
+        $page_url .= '/0';
         $full_theme = false;
     }
 }
 
-$base_url_rewrite = nv_url_rewrite($base_url, true);
-$base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
-$request_uri = rawurldecode($_SERVER['REQUEST_URI']);
-if (str_starts_with($request_uri, $base_url_check)) {
-    $canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($canonicalUrl, true);
-} elseif (str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {
-    $canonicalUrl = nv_url_rewrite($canonicalUrl, true);
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
 } else {
-    nv_redirect_location($base_url_check);
+    $canonicalUrl = $base_url_rewrite;
 }
 
 $array_content = [
@@ -303,7 +301,7 @@ $array_content = [
     'bodytext' => $module_config[$module_name]['bodytext']
 ];
 
-$contents = contact_main_theme($array_content, $array_department, $catsName, $base_url, NV_CHECK_SESSION);
+$contents = contact_main_theme($array_content, $array_department, $catsName, $page_url, NV_CHECK_SESSION);
 
 include NV_ROOTDIR . '/includes/header.php';
 echo nv_site_theme($contents, $full_theme);

--- a/modules/feeds/funcs/main.php
+++ b/modules/feeds/funcs/main.php
@@ -79,15 +79,16 @@ function nv_get_sub_rss_link($rssarray, $id)
 }
 
 $page_title = $module_info['site_title'];
-$base_url_rewrite = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name, true);
-$base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
-$request_uri = rawurldecode($_SERVER['REQUEST_URI']);
-if (str_starts_with($request_uri, $base_url_check)) {
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
+
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
     $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
-} elseif (str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {
-    $canonicalUrl = $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
 } else {
-    nv_redirect_location($base_url_check);
+    $canonicalUrl = $base_url_rewrite;
 }
 
 $array = '';

--- a/modules/news/funcs/author.php
+++ b/modules/news/funcs/author.php
@@ -33,13 +33,13 @@ if (!empty($author_info['image'])) {
 $author_info['add_time_format'] = nv_date("d/m/Y", $author_info['add_time']);
 
 $page_title = $author_info['pseudonym'];
-$base_url = $base_url_rewrite = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=author/' . $author_info['alias'];
+$page_url = $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=author/' . $author_info['alias'];
 if ($page > 1) {
-    $base_url_rewrite .= '/page-' . $page;
+    $page_url .= '/page-' . $page;
     $page_title .= NV_TITLEBAR_DEFIS . $lang_global['page'] . ' ' . $page;
 }
 
-$base_url_rewrite = nv_url_rewrite($base_url_rewrite, true);
+$base_url_rewrite = nv_url_rewrite($page_url, true);
 $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
 $request_uri = rawurldecode($_SERVER['REQUEST_URI']);
 if (!str_starts_with($request_uri, $base_url_check) and !str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {

--- a/modules/news/funcs/content.php
+++ b/modules/news/funcs/content.php
@@ -42,6 +42,8 @@ if (defined('NV_EDITOR')) {
 
 $page_title = $lang_module['content'];
 $key_words = $module_info['keywords'];
+$page_url = $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 // check user post content
 $array_post_config = [];
@@ -106,9 +108,6 @@ if ($array_post_user['postcontent']) {
     $array_post_user['addcontent'] = 1;
 }
 
-$base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $op;
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($base_url, true);
-
 $array_mod_title[] = [
     'catid' => 0,
     'title' => $lang_module['content'],
@@ -154,6 +153,9 @@ $my_author_detail = defined('NV_IS_USER') ? my_author_detail($user_info['userid'
 
 // Chinh sua thong tin tac gia
 if (defined('NV_IS_USER') and $nv_Request->isset_request('author_info', 'get')) {
+    $page_url .= '&amp;author_info=1';
+    $canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
+
     if ($nv_Request->isset_request('save', 'post')) {
         $pseudonym = $nv_Request->get_title('pseudonym', 'post', '', 1);
         if (empty($pseudonym)) {
@@ -233,6 +235,9 @@ $layout_array = nv_scandir(NV_ROOTDIR . '/themes/' . $selectthemes . '/layout', 
 $reCaptchaPass = (!empty($global_config['recaptcha_sitekey']) and !empty($global_config['recaptcha_secretkey']) and ($global_config['recaptcha_ver'] == 2 or $global_config['recaptcha_ver'] == 3));
 
 if ($nv_Request->isset_request('contentid', 'get,post') and $fcheckss == $checkss) {
+    $page_url .= '&amp;author_info=1';
+    $canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
+
     if ($contentid > 0) {
         if (!defined('NV_IS_USER')) {
             nv_redirect_location($base_url);
@@ -750,6 +755,9 @@ if ($nv_Request->isset_request('contentid', 'get,post') and $fcheckss == $checks
 
     if (isset($array_op[1]) and substr($array_op[1], 0, 5) == 'page-') {
         $page = intval(substr($array_op[1], 5));
+
+        $page_url .= '/page-' . $page;
+        $canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
     }
 
     $xtpl = new XTemplate('content.tpl', NV_ROOTDIR . '/themes/' . $module_info['template'] . '/modules/' . $module_info['module_theme']);

--- a/modules/news/funcs/detail.php
+++ b/modules/news/funcs/detail.php
@@ -24,198 +24,196 @@ if (empty($module_config[$module_name]['identify_cat_change'])) {
 }
 $news_contents = $query->fetch();
 
-if (!empty($news_contents)) {
-    $body_contents = $db_slave->query('SELECT titlesite, description, bodyhtml, keywords, sourcetext, files, layout_func, imgposition, copyright, allowed_send, allowed_print, allowed_save FROM ' . NV_PREFIXLANG . '_' . $module_data . '_detail where id=' . $news_contents['id'])->fetch();
-    $news_contents = array_merge($news_contents, $body_contents);
-    unset($body_contents);
+if (empty($news_contents)) {
+    $redirect = '<meta http-equiv="Refresh" content="3;URL=' . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name, true) . '" />';
+    nv_info_die($lang_global['error_404_title'], $lang_global['error_404_title'], $lang_global['error_404_content'] . $redirect, 404);
+}
 
-    // Tải về đính kèm
-    if ($nv_Request->isset_request('download', 'get')) {
-        $fileid = $nv_Request->get_int('id', 'get', 0);
+$body_contents = $db_slave->query('SELECT titlesite, description, bodyhtml, keywords, sourcetext, files, layout_func, imgposition, copyright, allowed_send, allowed_print, allowed_save FROM ' . NV_PREFIXLANG . '_' . $module_data . '_detail where id=' . $news_contents['id'])->fetch();
+$news_contents = array_merge($news_contents, $body_contents);
+unset($body_contents);
 
-        $news_contents['files'] = explode(',', $news_contents['files']);
+// Tải về đính kèm
+if ($nv_Request->isset_request('download', 'get')) {
+    $fileid = $nv_Request->get_int('id', 'get', 0);
 
-        if (!isset($news_contents['files'][$fileid])) {
-            nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name, true);
-        }
+    $news_contents['files'] = explode(',', $news_contents['files']);
 
-        if (!file_exists(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid])) {
-            nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name, true);
-        }
-
-        $file_info = pathinfo(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid]);
-        $download = new NukeViet\Files\Download(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid], $file_info['dirname'], $file_info['basename'], true);
-        $download->download_file();
-        exit();
+    if (!isset($news_contents['files'][$fileid])) {
+        nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name, true);
     }
 
-    // Xem đính kèm dạng PDF
-    if ($nv_Request->isset_request('pdf', 'get')) {
-        $fileid = $nv_Request->get_int('id', 'get', 0);
-
-        $news_contents['files'] = explode(',', $news_contents['files']);
-
-        if (!isset($news_contents['files'][$fileid])) {
-            nv_info_die($lang_global['error_404_title'], $lang_global['error_404_title'], $lang_global['error_404_content'], 404);
-        }
-
-        if (!file_exists(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid])) {
-            nv_info_die($lang_global['error_404_title'], $lang_global['error_404_title'], $lang_global['error_404_content'], 404);
-        }
-
-        $file_url = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $global_array_cat[$news_contents['catid']]['alias'] . '/' . $news_contents['alias'] . '-' . $news_contents['id'] . $global_config['rewrite_exturl'], true) . '?download=1&id=' . $fileid;
-
-        $contents = nv_theme_viewpdf($file_url);
-        nv_htmlOutput($contents);
+    if (!file_exists(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid])) {
+        nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name, true);
     }
 
-    // Kiểm tra URL, không cho đánh tùy ý phần alias
-    $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $global_array_cat[$news_contents['catid']]['alias'] . '/' . $news_contents['alias'] . '-' . $news_contents['id'] . $global_config['rewrite_exturl'];
-    $base_url_rewrite = nv_url_rewrite($base_url, true);
-    $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
-    $request_uri = rawurldecode($_SERVER['REQUEST_URI']);
-    if (!str_starts_with($request_uri, $base_url_check) and !str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {
-        nv_redirect_location($base_url_rewrite);
-    }
-    $news_contents['link'] = $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+    $file_info = pathinfo(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid]);
+    $download = new NukeViet\Files\Download(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid], $file_info['dirname'], $file_info['basename'], true);
+    $download->download_file();
+    exit();
+}
 
-    /*
-     * Không có quyền xem bài viết thì dừng
-     * Lưu ý tới đây thì $catid này đã là $catid chính thức vì không chính thức thì
-     * bên trên đã được chuyển hướng
-     */
-    if (!nv_user_in_groups($global_array_cat[$catid]['groups_view'])) {
-        $nv_BotManager->setPrivate();
-        $contents = no_permission($global_array_cat[$catid]['groups_view']);
+// Xem đính kèm dạng PDF
+if ($nv_Request->isset_request('pdf', 'get')) {
+    $fileid = $nv_Request->get_int('id', 'get', 0);
 
-        include NV_ROOTDIR . '/includes/header.php';
-        echo nv_site_theme($contents);
-        include NV_ROOTDIR . '/includes/footer.php';
+    $news_contents['files'] = explode(',', $news_contents['files']);
+
+    if (!isset($news_contents['files'][$fileid])) {
+        nv_info_die($lang_global['error_404_title'], $lang_global['error_404_title'], $lang_global['error_404_content'], 404);
     }
 
-    // Mở bài viết sang nguồn tin chính thức
-    if ($news_contents['external_link']) {
-        nv_redirect_location($news_contents['sourcetext'], 0, true);
+    if (!file_exists(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['files'][$fileid])) {
+        nv_info_die($lang_global['error_404_title'], $lang_global['error_404_title'], $lang_global['error_404_content'], 404);
     }
 
-    $page_title = empty($news_contents['titlesite']) ? $news_contents['title'] : $news_contents['titlesite'];
+    $file_url = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $global_array_cat[$news_contents['catid']]['alias'] . '/' . $news_contents['alias'] . '-' . $news_contents['id'] . $global_config['rewrite_exturl'], true) . '?download=1&id=' . $fileid;
 
-    $show_no_image = $module_config[$module_name]['show_no_image'];
+    $contents = nv_theme_viewpdf($file_url);
+    nv_htmlOutput($contents);
+}
 
-    if (defined('NV_IS_MODADMIN') or ($news_contents['status'] == 1 and $news_contents['publtime'] < NV_CURRENTTIME and ($news_contents['exptime'] == 0 or $news_contents['exptime'] > NV_CURRENTTIME))) {
-        $time_set = $nv_Request->get_int($module_data . '_' . $op . '_' . $id, 'session');
-        if (empty($time_set)) {
-            $nv_Request->set_Session($module_data . '_' . $op . '_' . $id, NV_CURRENTTIME);
-            $query = 'UPDATE ' . NV_PREFIXLANG . '_' . $module_data . '_rows SET hitstotal=hitstotal+1 WHERE id=' . $id;
+// Kiểm tra URL, không cho đánh tùy ý phần alias
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $global_array_cat[$news_contents['catid']]['alias'] . '/' . $news_contents['alias'] . '-' . $news_contents['id'] . $global_config['rewrite_exturl'];
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
+$request_uri = rawurldecode($_SERVER['REQUEST_URI']);
+if (!str_starts_with($request_uri, $base_url_check) and !str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {
+    nv_redirect_location($base_url_rewrite);
+}
+$news_contents['link'] = $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+
+/*
+ * Không có quyền xem bài viết thì dừng
+ * Lưu ý tới đây thì $catid này đã là $catid chính thức vì không chính thức thì
+ * bên trên đã được chuyển hướng
+ */
+if (!nv_user_in_groups($global_array_cat[$catid]['groups_view'])) {
+    $nv_BotManager->setPrivate();
+    $contents = no_permission($global_array_cat[$catid]['groups_view']);
+
+    include NV_ROOTDIR . '/includes/header.php';
+    echo nv_site_theme($contents);
+    include NV_ROOTDIR . '/includes/footer.php';
+}
+
+// Mở bài viết sang nguồn tin chính thức
+if ($news_contents['external_link']) {
+    nv_redirect_location($news_contents['sourcetext'], 0, true);
+}
+
+$page_title = empty($news_contents['titlesite']) ? $news_contents['title'] : $news_contents['titlesite'];
+
+$show_no_image = $module_config[$module_name]['show_no_image'];
+
+if (defined('NV_IS_MODADMIN') or ($news_contents['status'] == 1 and $news_contents['publtime'] < NV_CURRENTTIME and ($news_contents['exptime'] == 0 or $news_contents['exptime'] > NV_CURRENTTIME))) {
+    $time_set = $nv_Request->get_int($module_data . '_' . $op . '_' . $id, 'session');
+    if (empty($time_set)) {
+        $nv_Request->set_Session($module_data . '_' . $op . '_' . $id, NV_CURRENTTIME);
+        $query = 'UPDATE ' . NV_PREFIXLANG . '_' . $module_data . '_rows SET hitstotal=hitstotal+1 WHERE id=' . $id;
+        $db->query($query);
+
+        $array_catid = explode(',', $news_contents['listcatid']);
+        foreach ($array_catid as $catid_i) {
+            $query = 'UPDATE ' . NV_PREFIXLANG . '_' . $module_data . '_' . $catid_i . ' SET hitstotal=hitstotal+1 WHERE id=' . $id;
             $db->query($query);
+        }
+    }
+    $news_contents['showhometext'] = $module_config[$module_name]['showhometext'];
+    if (!empty($news_contents['homeimgfile'])) {
+        $homeimgfile = $news_contents['homeimgfile'];
+        $news_contents['srcset'] = '';
 
-            $array_catid = explode(',', $news_contents['listcatid']);
-            foreach ($array_catid as $catid_i) {
-                $query = 'UPDATE ' . NV_PREFIXLANG . '_' . $module_data . '_' . $catid_i . ' SET hitstotal=hitstotal+1 WHERE id=' . $id;
-                $db->query($query);
+        $src = $alt = $note = '';
+        $width = $height = 0;
+        if ($news_contents['homeimgthumb'] == 1 and $news_contents['imgposition'] == 1) {
+            $src = NV_BASE_SITEURL . NV_FILES_DIR . '/' . $module_upload . '/' . $homeimgfile;
+            $news_contents['homeimgfile'] = NV_BASE_SITEURL . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $homeimgfile;
+            $width = $module_config[$module_name]['homewidth'];
+
+            if (file_exists(NV_ROOTDIR . '/' . NV_MOBILE_FILES_DIR . '/' . $module_upload . '/' . $homeimgfile)) {
+                $imagesize = @getimagesize(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $homeimgfile);
+                $news_contents['srcset'] = NV_BASE_SITEURL . NV_MOBILE_FILES_DIR . '/' . $module_upload . '/' . $homeimgfile . ' ' . NV_MOBILE_MODE_IMG . 'w, ';
+                $news_contents['srcset'] .= $news_contents['homeimgfile'] . ' ' . $imagesize[0] . 'w';
+            }
+        } elseif ($news_contents['homeimgthumb'] == 3) {
+            $src = $news_contents['homeimgfile'];
+            $width = ($news_contents['imgposition'] == 1) ? $module_config[$module_name]['homewidth'] : $module_config[$module_name]['imagefull'];
+        } elseif (file_exists(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile'])) {
+            $src = NV_BASE_SITEURL . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile'];
+            $imagesize = @getimagesize(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile']);
+            if ($news_contents['imgposition'] == 1) {
+                $width = $module_config[$module_name]['homewidth'];
+            } else {
+                if ($imagesize[0] > 0 and $imagesize[0] > $module_config[$module_name]['imagefull']) {
+                    $width = $module_config[$module_name]['imagefull'];
+                } else {
+                    $width = $imagesize[0];
+                }
+            }
+            $news_contents['homeimgfile'] = $src;
+
+            if (file_exists(NV_ROOTDIR . '/' . NV_MOBILE_FILES_DIR . '/' . $module_upload . '/' . $homeimgfile)) {
+                $news_contents['srcset'] = NV_BASE_SITEURL . NV_MOBILE_FILES_DIR . '/' . $module_upload . '/' . $homeimgfile . ' ' . NV_MOBILE_MODE_IMG . 'w, ';
+                $news_contents['srcset'] .= $news_contents['homeimgfile'] . ' ' . $imagesize[0] . 'w';
             }
         }
-        $news_contents['showhometext'] = $module_config[$module_name]['showhometext'];
-        if (!empty($news_contents['homeimgfile'])) {
-            $homeimgfile = $news_contents['homeimgfile'];
-            $news_contents['srcset'] = '';
-            
-            $src = $alt = $note = '';
-            $width = $height = 0;
-            if ($news_contents['homeimgthumb'] == 1 and $news_contents['imgposition'] == 1) {
-                $src = NV_BASE_SITEURL . NV_FILES_DIR . '/' . $module_upload . '/' . $homeimgfile;
-                $news_contents['homeimgfile'] = NV_BASE_SITEURL . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $homeimgfile;
-                $width = $module_config[$module_name]['homewidth'];
-                
-                if (file_exists(NV_ROOTDIR . '/' . NV_MOBILE_FILES_DIR . '/' . $module_upload . '/' . $homeimgfile)) {
-                    $imagesize = @getimagesize(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $homeimgfile);
-                    $news_contents['srcset'] = NV_BASE_SITEURL . NV_MOBILE_FILES_DIR . '/' . $module_upload . '/' . $homeimgfile . ' ' . NV_MOBILE_MODE_IMG . 'w, ';
-                    $news_contents['srcset'] .= $news_contents['homeimgfile'] . ' ' . $imagesize[0] . 'w';
-                }
-            } elseif ($news_contents['homeimgthumb'] == 3) {
-                $src = $news_contents['homeimgfile'];
-                $width = ($news_contents['imgposition'] == 1) ? $module_config[$module_name]['homewidth'] : $module_config[$module_name]['imagefull'];
-            } elseif (file_exists(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile'])) {
-                $src = NV_BASE_SITEURL . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile'];
-                $imagesize = @getimagesize(NV_UPLOADS_REAL_DIR . '/' . $module_upload . '/' . $news_contents['homeimgfile']);
-                if ($news_contents['imgposition'] == 1) {
-                    $width = $module_config[$module_name]['homewidth'];
-                } else {
-                    if ($imagesize[0] > 0 and $imagesize[0] > $module_config[$module_name]['imagefull']) {
-                        $width = $module_config[$module_name]['imagefull'];
-                    } else {
-                        $width = $imagesize[0];
-                    }
-                }
-                $news_contents['homeimgfile'] = $src;
 
-                if (file_exists(NV_ROOTDIR . '/' . NV_MOBILE_FILES_DIR . '/' . $module_upload . '/' . $homeimgfile)) {
-                    $news_contents['srcset'] = NV_BASE_SITEURL . NV_MOBILE_FILES_DIR . '/' . $module_upload . '/' . $homeimgfile . ' ' . NV_MOBILE_MODE_IMG . 'w, ';
-                    $news_contents['srcset'] .= $news_contents['homeimgfile'] . ' ' . $imagesize[0] . 'w';
-                }
-            }
-
-            if (!empty($src)) {
-                $meta_property['og:image'] = (preg_match('/^(http|https|ftp|gopher)\:\/\//', $news_contents['homeimgfile'])) ? $news_contents['homeimgfile'] : NV_MY_DOMAIN . $news_contents['homeimgfile'];
-                if ($news_contents['imgposition'] > 0) {
-                    $news_contents['image'] = [
-                        'src' => $src,
-                        'width' => $width,
-                        'alt' => (empty($news_contents['homeimgalt'])) ? $news_contents['title'] : $news_contents['homeimgalt'],
-                        'note' => $news_contents['homeimgalt'],
-                        'position' => $news_contents['imgposition']
-                    ];
-                }
-            } elseif (!empty($show_no_image)) {
-                $meta_property['og:image'] = NV_MY_DOMAIN . NV_BASE_SITEURL . $show_no_image;
+        if (!empty($src)) {
+            $meta_property['og:image'] = (preg_match('/^(http|https|ftp|gopher)\:\/\//', $news_contents['homeimgfile'])) ? $news_contents['homeimgfile'] : NV_MY_DOMAIN . $news_contents['homeimgfile'];
+            if ($news_contents['imgposition'] > 0) {
+                $news_contents['image'] = [
+                    'src' => $src,
+                    'width' => $width,
+                    'alt' => (empty($news_contents['homeimgalt'])) ? $news_contents['title'] : $news_contents['homeimgalt'],
+                    'note' => $news_contents['homeimgalt'],
+                    'position' => $news_contents['imgposition']
+                ];
             }
         } elseif (!empty($show_no_image)) {
             $meta_property['og:image'] = NV_MY_DOMAIN . NV_BASE_SITEURL . $show_no_image;
         }
-
-        // File download
-        if (!empty($news_contents['files'])) {
-            $news_contents['files'] = explode(',', $news_contents['files']);
-            $files = $news_contents['files'];
-            $news_contents['files'] = [];
-
-            foreach ($files as $file_id => $file) {
-                $is_localfile = (!nv_is_url($file));
-                $file_title = $is_localfile ? basename($file) : $lang_module['click_to_download'];
-                $news_contents['files'][] = [
-                    'title' => $file_title,
-                    'key' => md5($file_id . $file_title),
-                    'ext' => nv_getextension($file_title),
-                    'titledown' => $lang_module['download'] . ' ' . (count($files) > 1 ? $file_id + 1 : ''),
-                    'src' => NV_BASE_SITEURL . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $file,
-                    'url' => $is_localfile ? ($base_url . '&amp;download=1&amp;id=' . $file_id) : $file,
-                    'urlpdf' => $base_url . '&amp;pdf=1&amp;id=' . $file_id,
-                    'urldoc' => $is_localfile ? $file : ('https://docs.google.com/viewer?embedded=true&url=' . NV_MY_DOMAIN . '/' . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $file)
-                ];
-            }
-        }
-
-        $publtime = intval($news_contents['publtime']);
-        $meta_property['og:type'] = 'article';
-        $meta_property['article:published_time'] = date('Y-m-dTH:i:s', $publtime);
-        $meta_property['article:modified_time'] = date('Y-m-dTH:i:s', $news_contents['edittime']);
-        if ($news_contents['exptime']) {
-            $meta_property['article:expiration_time'] = date('Y-m-dTH:i:s', $news_contents['exptime']);
-        }
-        $meta_property['article:section'] = $global_array_cat[$news_contents['catid']]['title'];
+    } elseif (!empty($show_no_image)) {
+        $meta_property['og:image'] = NV_MY_DOMAIN . NV_BASE_SITEURL . $show_no_image;
     }
 
-    if (defined('NV_IS_MODADMIN') and $news_contents['status'] != 1) {
-        $alert = sprintf($lang_module['status_alert'], $lang_module['status_' . $news_contents['status']]);
-        $my_footer .= "<script type=\"text/javascript\">alert('" . $alert . "')</script>";
-        $news_contents['allowed_send'] = 0;
-        $module_config[$module_name]['socialbutton'] = 0;
+    // File download
+    if (!empty($news_contents['files'])) {
+        $news_contents['files'] = explode(',', $news_contents['files']);
+        $files = $news_contents['files'];
+        $news_contents['files'] = [];
+
+        foreach ($files as $file_id => $file) {
+            $is_localfile = (!nv_is_url($file));
+            $file_title = $is_localfile ? basename($file) : $lang_module['click_to_download'];
+            $news_contents['files'][] = [
+                'title' => $file_title,
+                'key' => md5($file_id . $file_title),
+                'ext' => nv_getextension($file_title),
+                'titledown' => $lang_module['download'] . ' ' . (count($files) > 1 ? $file_id + 1 : ''),
+                'src' => NV_BASE_SITEURL . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $file,
+                'url' => $is_localfile ? ($page_url . '&amp;download=1&amp;id=' . $file_id) : $file,
+                'urlpdf' => $page_url . '&amp;pdf=1&amp;id=' . $file_id,
+                'urldoc' => $is_localfile ? $file : ('https://docs.google.com/viewer?embedded=true&url=' . NV_MY_DOMAIN . '/' . NV_UPLOADS_DIR . '/' . $module_upload . '/' . $file)
+            ];
+        }
     }
+
+    $publtime = intval($news_contents['publtime']);
+    $meta_property['og:type'] = 'article';
+    $meta_property['article:published_time'] = date('Y-m-dTH:i:s', $publtime);
+    $meta_property['article:modified_time'] = date('Y-m-dTH:i:s', $news_contents['edittime']);
+    if ($news_contents['exptime']) {
+        $meta_property['article:expiration_time'] = date('Y-m-dTH:i:s', $news_contents['exptime']);
+    }
+    $meta_property['article:section'] = $global_array_cat[$news_contents['catid']]['title'];
 }
 
-if ($publtime == 0) {
-    $redirect = '<meta http-equiv="Refresh" content="3;URL=' . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name, true) . '" />';
-    nv_info_die($lang_global['error_404_title'], $lang_global['error_404_title'], $lang_global['error_404_content'] . $redirect, 404);
+if (defined('NV_IS_MODADMIN') and $news_contents['status'] != 1) {
+    $alert = sprintf($lang_module['status_alert'], $lang_module['status_' . $news_contents['status']]);
+    $my_footer .= "<script type=\"text/javascript\">alert('" . $alert . "')</script>";
+    $news_contents['allowed_send'] = 0;
+    $module_config[$module_name]['socialbutton'] = 0;
 }
 
 $news_contents['url_sendmail'] = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=sendmail/' . $global_array_cat[$catid]['alias'] . '/' . $news_contents['alias'] . '-' . $news_contents['id'] . $global_config['rewrite_exturl'], true);

--- a/modules/news/funcs/instant-rss.php
+++ b/modules/news/funcs/instant-rss.php
@@ -36,6 +36,7 @@ $gettime = empty($module_config[$module_name]['instant_articles_gettime']) ? 0 :
 $channel['title'] = $module_info['custom_title'];
 $channel['link'] = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
 $channel['description'] = !empty($module_info['description']) ? $module_info['description'] : $global_config['site_description'];
+$atomlink = NV_BASE_SITEURL . "index.php?" . NV_LANG_VARIABLE . "=" . NV_LANG_DATA . "&amp;" . NV_NAME_VARIABLE . "=" . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $module_info['alias']['rss'];
 
 $catid = 0;
 if (isset($array_op[1])) {
@@ -58,6 +59,7 @@ if (!empty($catid)) {
     $channel['title'] = $module_info['custom_title'] . ' - ' . $global_array_cat[$catid]['title'];
     $channel['link'] = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $alias_cat_url;
     $channel['description'] = $global_array_cat[$catid]['description'];
+    $atomlink .= '/' . $alias_cat_url;
 
     $db_slave->from(NV_PREFIXLANG . '_' . $module_data . '_' . $catid)->where('status=1 AND instant_active=1' . ($gettime ? ' AND (publtime>= ' . $gettime . ' OR edittime >= ' . $gettime . ')' : ''));
 } else {
@@ -132,5 +134,5 @@ if (!defined('NV_IS_MODADMIN') and ($cache = $nv_Cache->getItem($module_name, $c
     }
 }
 
-nv_rss_generate($channel, $items, 'ISO8601');
+nv_rss_generate($channel, $items, $atomlink, 'ISO8601');
 die();

--- a/modules/news/funcs/main.php
+++ b/modules/news/funcs/main.php
@@ -14,10 +14,10 @@ if (!defined('NV_IS_MOD_NEWS')) {
 
 $page_title = $module_info['site_title'];
 $key_words = $module_info['keywords'];
+$page_url = $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
 
 $contents = '';
 $cache_file = '';
-$base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
 $isMob = ((!empty($global_config['mobile_theme']) and $module_info['template'] == $global_config['mobile_theme']) or $client_info['is_mobile']);
 $viewcat = $isMob ? $module_config[$module_name]['mobile_indexfile'] : $module_config[$module_name]['indexfile'];
 $no_generate = ['viewcat_none', 'viewcat_main_left', 'viewcat_main_right', 'viewcat_main_bottom', 'viewcat_two_column'];
@@ -31,7 +31,19 @@ if (($page < 2 and isset($array_op[0])) or isset($array_op[1]) or ($page > 1 and
     nv_redirect_location($base_url);
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($base_url . ($page > 1 ? ('&amp;' . NV_OP_VARIABLE . '=page-' . $page) : ''), true);
+if ($page > 1) {
+    $page_url .= '&amp;' . NV_OP_VARIABLE . '=page-' . $page;
+}
+
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 if (!defined('NV_IS_MODADMIN') and $page < 5) {
     $cache_file = NV_LANG_DATA . '_' . $module_info['template'] . '-' . $op . '-' . $page . '-' . NV_CACHE_PREFIX . '.cache';

--- a/modules/news/funcs/print.php
+++ b/modules/news/funcs/print.php
@@ -37,7 +37,8 @@ if ($id > 0 and $catid > 0) {
     unset($sql, $result, $body_contents);
 
     if ($content['allowed_print'] == 1 and (defined('NV_IS_MODADMIN') or ($content['status'] == 1 and $content['publtime'] < NV_CURRENTTIME and ($content['exptime'] == 0 or $content['exptime'] > NV_CURRENTTIME)))) {
-        $base_url_rewrite = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=print/' . $global_array_cat[$catid]['alias'] . '/' . $content['alias'] . '-' . $id . $global_config['rewrite_exturl'], true);
+        $page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=print/' . $global_array_cat[$catid]['alias'] . '/' . $content['alias'] . '-' . $id . $global_config['rewrite_exturl'];
+        $base_url_rewrite = nv_url_rewrite($page_url, true);
         $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
         $request_uri = rawurldecode($_SERVER['REQUEST_URI']);
         if (!str_starts_with($request_uri, $base_url_check) and !str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {

--- a/modules/news/funcs/rss.php
+++ b/modules/news/funcs/rss.php
@@ -18,6 +18,7 @@ $items = [];
 $channel['title'] = $module_info['custom_title'];
 $channel['link'] = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
 $channel['description'] = !empty($module_info['description']) ? $module_info['description'] : $global_config['site_description'];
+$atomlink = NV_BASE_SITEURL . "index.php?" . NV_LANG_VARIABLE . "=" . NV_LANG_DATA . "&amp;" . NV_NAME_VARIABLE . "=" . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $module_info['alias']['rss'];
 
 $catid = 0;
 if (isset($array_op[1])) {
@@ -40,6 +41,7 @@ if (!empty($catid)) {
     $channel['title'] = $module_info['custom_title'] . ' - ' . $global_array_cat[$catid]['title'];
     $channel['link'] = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $alias_cat_url;
     $channel['description'] = $global_array_cat[$catid]['description'];
+    $atomlink .= '/' . $alias_cat_url;
 
     $db_slave->from(NV_PREFIXLANG . '_' . $module_data . '_' . $catid)->where('status=1');
 } else {
@@ -74,5 +76,5 @@ if ($module_info['rss']) {
         ];
     }
 }
-nv_rss_generate($channel, $items);
+nv_rss_generate($channel, $items, $atomlink);
 die();

--- a/modules/news/funcs/savefile.php
+++ b/modules/news/funcs/savefile.php
@@ -54,20 +54,20 @@ if ($id > 0 and $catid > 0) {
         unset($body_contents);
 
         if ($content['allowed_save'] == 1 and (defined('NV_IS_MODADMIN') or ($content['status'] == 1 and $content['publtime'] < NV_CURRENTTIME and ($content['exptime'] == 0 or $content['exptime'] > NV_CURRENTTIME)))) {
-            $base_url_rewrite = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=savefile/' . $global_array_cat[$catid]['alias'] . '/' . $content['alias'] . '-' . $id . $global_config['rewrite_exturl'], true);
+            $page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=savefile/' . $global_array_cat[$catid]['alias'] . '/' . $content['alias'] . '-' . $id . $global_config['rewrite_exturl'];
+            $base_url_rewrite = nv_url_rewrite($page_url, true);
             $request_uri = rawurldecode($_SERVER['REQUEST_URI']);
             if ($request_uri != $base_url_rewrite and NV_MAIN_DOMAIN . $request_uri != $base_url_rewrite) {
                 nv_redirect_location($base_url_rewrite);
             }
 
+            $base_url_rewrite = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $global_array_cat[$catid]['alias'] . '/' . $content['alias'] . '-' . $id . $global_config['rewrite_exturl'], true);
+            $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+
             $sql = 'SELECT title FROM ' . NV_PREFIXLANG . '_' . $module_data . '_sources WHERE sourceid = ' . $content['sourceid'];
             $result = $db_slave->query($sql);
             $sourcetext = $result->fetchColumn();
             unset($sql, $result);
-
-            $base_url_rewrite = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $global_array_cat[$catid]['alias'] . '/' . $content['alias'] . '-' . $id . $global_config['rewrite_exturl'], true);
-
-            $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
 
             $meta_tags = nv_html_meta_tags();
             $content['bodytext'] = $db_slave->query('SELECT bodyhtml FROM ' . NV_PREFIXLANG . '_' . $module_data . '_detail where id=' . $content['id'])->fetchColumn();

--- a/modules/news/funcs/search.php
+++ b/modules/news/funcs/search.php
@@ -61,42 +61,43 @@ function BoldKeywordInStr($str, $keyword)
 }
 
 $key = $nv_Request->get_title('q', 'get', '');
+$key = str_replace(["'", '"', '<', '>', "&#039;", "&quot;", "&lt;", "&gt;"], '', $key);
 $key = str_replace('+', ' ', urldecode($key));
 $key = trim(nv_substr($key, 0, NV_MAX_SEARCH_LENGTH));
 $keyhtml = nv_htmlspecialchars($key);
 
-$base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
 if (!empty($key)) {
-    $base_url .= '&q=' . urlencode($key);
+    $page_url .= '&q=' . urlencode($key);
 }
 
 $choose = $nv_Request->get_int('choose', 'get', 0);
 if (!empty($choose)) {
-    $base_url .= '&choose=' . $choose;
+    $page_url .= '&choose=' . $choose;
 }
 
 $catid = $nv_Request->get_int('catid', 'get', 0);
 if (!empty($catid)) {
-    $base_url .= '&catid=' . $catid;
+    $page_url .= '&catid=' . $catid;
 }
 $from_date = $nv_Request->get_title('from_date', 'get', '', 0);
 $date_array['from_date'] = preg_replace('/[^0-9]/', '.', urldecode($from_date));
 if (preg_match('/^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{4})$/', $date_array['from_date'])) {
-    $base_url .= '&from_date=' . $date_array['from_date'];
+    $page_url .= '&from_date=' . $date_array['from_date'];
 }
 
 $to_date = $nv_Request->get_title('to_date', 'get', '', 0);
 $date_array['to_date'] = preg_replace('/[^0-9]/', '.', urldecode($to_date));
 if (preg_match('/^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{4})$/', $date_array['to_date'])) {
-    $base_url .= '&to_date=' . $date_array['to_date'];
+    $page_url .= '&to_date=' . $date_array['to_date'];
 }
 
-$base_url_rewrite = $base_url;
+$base_url = $page_url;
 $page = $nv_Request->get_int('page', 'get', 1);
 if ($page > 1) {
-    $base_url_rewrite .= '&page=' . $page;
+    $page_url .= '&page=' . $page;
 }
-$base_url_rewrite = nv_url_rewrite($base_url_rewrite, true);
+$base_url_rewrite = nv_url_rewrite($page_url, true);
 $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
 $request_uri = $_SERVER['REQUEST_URI'];
 if (str_starts_with($request_uri, $base_url_check)) {

--- a/modules/news/funcs/sendmail.php
+++ b/modules/news/funcs/sendmail.php
@@ -34,7 +34,8 @@ if ($id > 0 and $catid > 0) {
         if ($allowed_send == 1) {
             unset($sql, $result);
 
-            $base_url_rewrite = nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=sendmail/' . $global_array_cat[$catid]['alias'] . '/' . $alias . '-' . $id . $global_config['rewrite_exturl'], true);
+            $page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=sendmail/' . $global_array_cat[$catid]['alias'] . '/' . $alias . '-' . $id . $global_config['rewrite_exturl'];
+            $base_url_rewrite = nv_url_rewrite($page_url, true);
             $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
             $request_uri = rawurldecode($_SERVER['REQUEST_URI']);
             if (!str_starts_with($request_uri, $base_url_check) and !str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {

--- a/modules/news/funcs/tag.php
+++ b/modules/news/funcs/tag.php
@@ -33,13 +33,13 @@ if ($tid > 0) {
         $page_title = nv_ucfirst(trim(str_replace('-', ' ', $alias)));
     }
 
-    $base_url = $base_url_rewrite = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=tag/' . $alias;
+    $page_url = $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=tag/' . $alias;
     if ($page > 1) {
-        $base_url_rewrite .= '/page-' . $page;
+        $page_url .= '/page-' . $page;
         $page_title .= NV_TITLEBAR_DEFIS . $lang_global['page'] . ' ' . $page;
     }
 
-    $base_url_rewrite = nv_url_rewrite($base_url_rewrite, true);
+    $base_url_rewrite = nv_url_rewrite($page_url, true);
     $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
     $request_uri = rawurldecode($_SERVER['REQUEST_URI']);
     if (!str_starts_with($request_uri, $base_url_check) and !str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {

--- a/modules/news/funcs/topic.php
+++ b/modules/news/funcs/topic.php
@@ -11,7 +11,7 @@ if (!defined('NV_IS_MOD_NEWS')) {
     die('Stop!!!');
 }
 
-$base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $module_info['alias']['topic'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $module_info['alias']['topic'];
 
 $show_no_image = $module_config[$module_name]['show_no_image'];
 
@@ -38,13 +38,13 @@ if (!empty($alias)) {
         nv_redirect_location($base_url);
     }
 
-    $base_url .= '/' . $alias;
-    $base_url_rewrite = $base_url;
+    $page_url .= '/' . $alias;
+    $base_url = $page_url;
     if ($page > 1) {
         $page_title .= NV_TITLEBAR_DEFIS . $lang_global['page'] . ' ' . $page;
-        $base_url_rewrite .= '/page-' . $page;
+        $page_url .= '/page-' . $page;
     }
-    $base_url_rewrite = nv_url_rewrite($base_url_rewrite, true);
+    $base_url_rewrite = nv_url_rewrite($page_url, true);
     $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
     $request_uri = rawurldecode($_SERVER['REQUEST_URI']);
     if (!str_starts_with($request_uri, $base_url_check) and !str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {
@@ -130,7 +130,7 @@ if (!empty($alias)) {
 
     $contents = topic_theme($topic_array, $topic_other_array, $generate_page, $page_title, $description, $topic_image);
 } else {
-    $canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($base_url, true);
+    $canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
     $page_title = $module_info['funcs'][$op]['func_site_title'];
     $key_words = $module_info['keywords'];

--- a/modules/news/funcs/viewcat.php
+++ b/modules/news/funcs/viewcat.php
@@ -16,7 +16,7 @@ $cache_file = '';
 $contents = '';
 $viewcat = $global_array_cat[$catid]['viewcat'];
 $set_view_page = ($page > 1 and substr($viewcat, 0, 13) == 'viewcat_main_') ? true : false;
-$base_url = $global_array_cat[$catid]['link'];
+$page_url = $base_url = $global_array_cat[$catid]['link'];
 $no_generate = ['viewcat_two_column'];
 
 if (!defined('NV_IS_MODADMIN') and $page < 5) {
@@ -32,10 +32,20 @@ if (!defined('NV_IS_MODADMIN') and $page < 5) {
 
 // Kiểm tra và chặn đánh tùy ý các op
 if (($page < 2 and isset($array_op[1])) or isset($array_op[2]) or ($page > 1 and in_array($viewcat, $no_generate))) {
-    nv_redirect_location($base_url);
+    nv_redirect_location($page_url);
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($base_url . ($page > 1 ? ('/page-' . $page) : ''), true);
+if ($page > 1) {
+    $page_url .= '/page-' . $page;
+}
+
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
+$request_uri = rawurldecode($_SERVER['REQUEST_URI']);
+if (!str_starts_with($request_uri, $base_url_check) and !str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {
+    nv_redirect_location($base_url_check);
+}
+$canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
 
 $page_title = (!empty($global_array_cat[$catid]['titlesite'])) ? $global_array_cat[$catid]['titlesite'] : $global_array_cat[$catid]['title'];
 $key_words = $global_array_cat[$catid]['keywords'];

--- a/modules/news/theme.php
+++ b/modules/news/theme.php
@@ -764,7 +764,6 @@ function detail_theme($news_contents, $array_keyword, $related_new_array, $relat
     $xtpl->assign('NEWSID', $news_contents['id']);
     $xtpl->assign('NEWSCHECKSS', $news_contents['newscheckss']);
     $xtpl->assign('DETAIL', $news_contents);
-    $xtpl->assign('SELFURL', $client_info['selfurl']);
 
     if ($news_contents['allowed_send'] == 1) {
         $xtpl->assign('URL_SENDMAIL', $news_contents['url_sendmail']);

--- a/modules/page/funcs/main.php
+++ b/modules/page/funcs/main.php
@@ -12,8 +12,10 @@ if (!defined('NV_IS_MOD_PAGE')) {
     die('Stop!!!');
 }
 
+$page_url = $base_url;
+
 if ($page_config['viewtype'] == 2) {
-    $base_url_rewrite = nv_url_rewrite($base_url, true);
+    $base_url_rewrite = nv_url_rewrite($page_url, true);
     $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
     $request_uri = rawurldecode($_SERVER['REQUEST_URI']);
     if (!str_starts_with($request_uri, $base_url_check) and !str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {
@@ -28,11 +30,12 @@ if ($page_config['viewtype'] == 2) {
 
     // Không cho đánh op khi không hiển thị nội dung
     if (isset($array_op[0])) {
-        nv_redirect_location($base_url);
+        nv_redirect_location($page_url);
     }
 } elseif ($id) {
     // Xem theo bài viết
-    $base_url_rewrite = nv_url_rewrite($base_url . '&amp;' . NV_OP_VARIABLE . '=' . $rowdetail['alias'] . $global_config['rewrite_exturl'], true);
+    $page_url .= '&amp;' . NV_OP_VARIABLE . '=' . $rowdetail['alias'] . $global_config['rewrite_exturl'];
+    $base_url_rewrite = nv_url_rewrite($page_url, true);
     $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
     $request_uri = rawurldecode($_SERVER['REQUEST_URI']);
     if (!str_starts_with($request_uri, $base_url_check) and !str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {
@@ -141,7 +144,10 @@ if ($page_config['viewtype'] == 2) {
     $contents = nv_page_main($rowdetail, $other_links, $content_comment);
 } else {
     // Xem theo danh sách
-    $base_url_rewrite = nv_url_rewrite($base_url . ($page > 1 ? ('&amp;' . NV_OP_VARIABLE . '=page-' . $page) : ''), true);
+    if ($page > 1) {
+        $page_url .= '&amp;' . NV_OP_VARIABLE . '=page-' . $page;
+    }
+    $base_url_rewrite = nv_url_rewrite($page_url, true);
     $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
     $request_uri = rawurldecode($_SERVER['REQUEST_URI']);
     if (!str_starts_with($request_uri, $base_url_check) and !str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {

--- a/modules/page/funcs/rss.php
+++ b/modules/page/funcs/rss.php
@@ -18,6 +18,7 @@ $items = [];
 $channel['title'] = $module_info['custom_title'];
 $channel['link'] = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
 $channel['description'] = !empty($module_info['description']) ? $module_info['description'] : $global_config['site_description'];
+$atomlink = NV_BASE_SITEURL . "index.php?" . NV_LANG_VARIABLE . "=" . NV_LANG_DATA . "&amp;" . NV_NAME_VARIABLE . "=" . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $module_info['alias']['rss'];
 
 if ($module_info['rss']) {
     $sql = 'SELECT id, title, alias, image, imagealt, description, add_time FROM ' . NV_PREFIXLANG . '_' . $module_data . ' WHERE status=1 ORDER BY weight ASC LIMIT 20';
@@ -34,5 +35,5 @@ if ($module_info['rss']) {
         ];
     }
 }
-nv_rss_generate($channel, $items);
+nv_rss_generate($channel, $items, $atomlink);
 die();

--- a/modules/page/theme.php
+++ b/modules/page/theme.php
@@ -53,7 +53,7 @@ function nv_page_main($row, $ab_links, $content_comment)
                 $meta_property['fb:app_id'] = $page_config['facebookapi'];
                 $meta_property['og:locale'] = (NV_LANG_DATA == 'vi') ? 'vi_VN' : 'en_US';
             }
-            $xtpl->assign('SELFURL', $client_info['selfurl']);
+
             $xtpl->parse('main.socialbutton.facebook');
         }
         if (str_contains($page_config['socialbutton'], 'twitter')) {

--- a/modules/seek/funcs/main.php
+++ b/modules/seek/funcs/main.php
@@ -25,7 +25,7 @@ $search = [
     'content' => ''
 ];
 
-$base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name;
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name;
 
 if ($nv_Request->isset_request('q', 'get')) {
     $is_search = true;
@@ -43,26 +43,6 @@ if ($nv_Request->isset_request('q', 'get')) {
         $search['mod'] = 'all';
     }
 
-    $base_url .= '&q=' . urlencode($search['key']);
-    if ($search['mod'] != 'all') {
-        $base_url .= '&m=' . htmlspecialchars(nv_unhtmlspecialchars($search['mod']));
-    }
-    if ($search['logic'] != 1) {
-        $base_url .= '&l=' . $search['logic'];
-    }
-    
-    $base_url_rewrite = $base_url;
-    if ($search['page'] > 1) {
-        $base_url_rewrite .= '&page=' . $search['page'];
-    }
-    $base_url_rewrite = nv_url_rewrite($base_url_rewrite, true);
-    $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
-    $request_uri = $_SERVER['REQUEST_URI'];
-    if (!str_starts_with($request_uri, $base_url_check) and !str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {
-        nv_redirect_location($base_url_check);
-    }
-    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
-
     if (!empty($search['key'])) {
         if (!$search['logic']) {
             $search['key'] = preg_replace([
@@ -71,9 +51,30 @@ if ($nv_Request->isset_request('q', 'get')) {
                 "/\s([\S]{1})$/uis"
             ], " ", $search['key']);
         }
+        $search['key'] = str_replace(["'", '"', '<', '>', "&#039;", "&quot;", "&lt;", "&gt;"], '', $search['key']);
         $search['key'] = trim($search['key']);
         $search['len_key'] = nv_strlen($search['key']);
     }
+
+    $page_url .= '&q=' . urlencode($search['key']);
+    if ($search['mod'] != 'all') {
+        $page_url .= '&m=' . htmlspecialchars(nv_unhtmlspecialchars($search['mod']));
+    }
+    if ($search['logic'] != 1) {
+        $page_url .= '&l=' . $search['logic'];
+    }
+    
+    $base_url = $page_url;
+    if ($search['page'] > 1) {
+        $page_url .= '&page=' . $search['page'];
+    }
+    $base_url_rewrite = nv_url_rewrite($page_url, true);
+    $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
+    $request_uri = $_SERVER['REQUEST_URI'];
+    if (!str_starts_with($request_uri, $base_url_check) and !str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {
+        nv_redirect_location($base_url_check);
+    }
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
 
     if ($search['len_key'] < NV_MIN_SEARCH_LENGTH) {
         $search['is_error'] = true;
@@ -121,7 +122,7 @@ if ($nv_Request->isset_request('q', 'get')) {
         }
     }
 } else {
-    $base_url_rewrite = nv_url_rewrite($base_url, true);
+    $base_url_rewrite = nv_url_rewrite($page_url, true);
     $base_url_check = str_replace('&amp;', '&', $base_url_rewrite);
     $request_uri = rawurldecode($_SERVER['REQUEST_URI']);
     if (!str_starts_with($request_uri, $base_url_check) and !str_starts_with(NV_MY_DOMAIN . $request_uri, $base_url_check)) {

--- a/modules/statistics/funcs/allbots.php
+++ b/modules/statistics/funcs/allbots.php
@@ -12,10 +12,19 @@ if (! defined('NV_IS_MOD_STATISTICS')) {
     die('Stop!!!');
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op, true);
 $page_title = $lang_module['bot'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['bot'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 $result = $db->query("SELECT COUNT(*), MAX(c_count) FROM " . NV_COUNTER_GLOBALTABLE . " WHERE c_type='bot' AND c_count!=0");
 list($num_items, $max) = $result->fetch(3);

--- a/modules/statistics/funcs/allbrowsers.php
+++ b/modules/statistics/funcs/allbrowsers.php
@@ -12,10 +12,19 @@ if (! defined('NV_IS_MOD_STATISTICS')) {
     die('Stop!!!');
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op, true);
 $page_title = $lang_module['browser'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['browser'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 $sql = "SELECT COUNT(*), MAX(c_count) FROM " . NV_COUNTER_GLOBALTABLE . " WHERE c_type='browser' AND c_count!=0";
 $result = $db->query($sql);

--- a/modules/statistics/funcs/allcountries.php
+++ b/modules/statistics/funcs/allcountries.php
@@ -12,10 +12,19 @@ if (! defined('NV_IS_MOD_STATISTICS')) {
     die('Stop!!!');
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op, true);
 $page_title = $lang_module['country'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['country'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 $sql = "SELECT COUNT(*), MAX(c_count) FROM " . NV_COUNTER_GLOBALTABLE . " WHERE c_type='country' AND c_count!=0";
 $result = $db->query($sql);

--- a/modules/statistics/funcs/allos.php
+++ b/modules/statistics/funcs/allos.php
@@ -12,10 +12,19 @@ if (! defined('NV_IS_MOD_STATISTICS')) {
     die('Stop!!!');
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op, true);
 $page_title = $lang_module['os'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['os'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 $sql = "SELECT COUNT(*), MAX(c_count) FROM " . NV_COUNTER_GLOBALTABLE . " WHERE c_type='os' AND c_count!=0";
 $result = $db->query($sql);

--- a/modules/statistics/funcs/allreferers.php
+++ b/modules/statistics/funcs/allreferers.php
@@ -12,10 +12,19 @@ if (! defined('NV_IS_MOD_STATISTICS')) {
     die('Stop!!!');
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op, true);
 $page_title = $lang_module['referer'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['referer'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 $sql = 'SELECT COUNT(*), SUM(total), MAX(total) FROM ' . NV_REFSTAT_TABLE;
 $result = $db->query($sql);

--- a/modules/statistics/funcs/main.php
+++ b/modules/statistics/funcs/main.php
@@ -12,10 +12,19 @@ if (!defined('NV_IS_MOD_STATISTICS')) {
     die('Stop!!!');
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name, true);
 $page_title = $module_info['site_title'];
 $key_words = $module_info['keywords'];
 $mod_title = isset($lang_module['main_title']) ? $lang_module['main_title'] : $module_info['custom_title'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 $current_month_num = date('n', NV_CURRENTTIME);
 $current_year = date('Y', NV_CURRENTTIME);

--- a/modules/statistics/funcs/referer.php
+++ b/modules/statistics/funcs/referer.php
@@ -28,9 +28,18 @@ if (empty($row)) {
 }
 
 $contents = '';
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op . '&host=' . $host, true);
 $mod_title = $page_title = sprintf($lang_module['refererbysite'], $host);
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op . '&host=' . $host;
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
+}
 
 $cts = [];
 $cts['caption'] = $page_title;

--- a/modules/two-step-verification/funcs/confirm.php
+++ b/modules/two-step-verification/funcs/confirm.php
@@ -12,13 +12,16 @@ if (!defined('NV_MOD_2STEP_VERIFICATION')) {
     die('Stop!!!');
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op, true);
 $page_title = $module_info['site_title'];
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
 
 $nv_redirect = '';
 if ($nv_Request->isset_request('nv_redirect', 'post,get')) {
     $nv_redirect = nv_get_redirect();
+    if ($nv_Request->isset_request('nv_redirect', 'get')) {
+        $page_url .= '&amp;nv_redirect=' . $nv_redirect;
+    }
 }
 
 /**
@@ -90,6 +93,16 @@ if ($tokend_confirm_password != $tokend) {
         header('Location: ' . nv_redirect_decrypt($nv_redirect));
         die();
     }
+}
+
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
 }
 
 include NV_ROOTDIR . '/includes/header.php';

--- a/modules/two-step-verification/funcs/main.php
+++ b/modules/two-step-verification/funcs/main.php
@@ -12,9 +12,9 @@ if (!defined('NV_MOD_2STEP_VERIFICATION')) {
     die('Stop!!!');
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name, true);
 $page_title = $module_info['site_title'];
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name;
 
 // Tự động chuyển đến trang thiết lập nếu hệ thống bắt buộc xác thực ở quản trị, hoặc tất cả các khu vực
 if (empty($user_info['active2step']) and in_array($global_config['two_step_verification'], [1, 3])) {
@@ -69,6 +69,16 @@ $autoshowcode = false;
 if ($nv_Request->isset_request('showcode_' . $module_data, 'session')) {
     $autoshowcode = true;
     $nv_Request->unset_request('showcode_' . $module_data, 'session');
+}
+
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
 }
 
 $contents = nv_theme_info_2step($backupcodes, $autoshowcode);

--- a/modules/two-step-verification/funcs/setup.php
+++ b/modules/two-step-verification/funcs/setup.php
@@ -16,13 +16,16 @@ if (!empty($user_info['active2step'])) {
     nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name);
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op, true);
 $page_title = $module_info['site_title'];
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $op;
 
 $nv_redirect = '';
 if ($nv_Request->isset_request('nv_redirect', 'post,get')) {
     $nv_redirect = nv_get_redirect();
+    if ($nv_Request->isset_request('nv_redirect', 'get') and !empty($nv_redirect)) {
+        $page_url .= '&amp;nv_redirect=' . $nv_redirect;
+    }
 }
 
 /**
@@ -86,6 +89,16 @@ if ($checkss == NV_CHECK_SESSION) {
         'input' => '',
         'mess' => ''
     ));
+}
+
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
 }
 
 $contents = nv_theme_config_2step($secretkey, $nv_redirect);

--- a/modules/users/funcs/active.php
+++ b/modules/users/funcs/active.php
@@ -39,6 +39,8 @@ if (empty($row)) {
 
 $page_title = $mod_title = $lang_module['register'];
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 $check_update_user = false;
 $is_change_email = false;

--- a/modules/users/funcs/avatar.php
+++ b/modules/users/funcs/avatar.php
@@ -90,6 +90,8 @@ function deleteAvatar()
 }
 
 $page_title = $lang_module['avatar_pagetitle'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 $array = array();
 $array['success'] = 0;

--- a/modules/users/funcs/editinfo.php
+++ b/modules/users/funcs/editinfo.php
@@ -1087,6 +1087,8 @@ if ($checkss == $array_data['checkss'] and $array_data['type'] == 'basic') {
 
 $page_title = $mod_title = $lang_module['editinfo_pagetitle'];
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 if (!defined('NV_EDITOR')) {
     define('NV_EDITOR', 'ckeditor');

--- a/modules/users/funcs/groups.php
+++ b/modules/users/funcs/groups.php
@@ -13,6 +13,9 @@ if (!defined('NV_IS_MOD_USER')) {
 }
 
 $page_title = $lang_module['group_manage'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
+
 $contents = '';
 
 // Lay danh sach nhom

--- a/modules/users/funcs/login.php
+++ b/modules/users/funcs/login.php
@@ -836,10 +836,11 @@ if ($nv_Request->get_int('nv_ajax', 'post', 0) == 1) {
     die(nv_url_rewrite(user_login(true), true));
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op, true);
 $page_title = $lang_module['login'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['login'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 $contents = user_login();
 

--- a/modules/users/funcs/logout.php
+++ b/modules/users/funcs/logout.php
@@ -49,6 +49,8 @@ if ($nv_ajax_login) {
 $page_title = $module_info['site_title'];
 $key_words = $module_info['keywords'];
 $mod_title = isset($lang_module['main_title']) ? $lang_module['main_title'] : $module_info['custom_title'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 $info = $lang_module['logout_ok'] . '<br /><br />';
 $info .= '<img border="0" src="' . NV_STATIC_URL . NV_ASSETS_DIR . '/images/load_bar.gif"><br /><br />';

--- a/modules/users/funcs/lostactivelink.php
+++ b/modules/users/funcs/lostactivelink.php
@@ -25,9 +25,10 @@ if ($global_config['allowuserreg'] != 2) {
     nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name);
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op, true);
 $page_title = $mod_title = $lang_module['lostpass_page_title'];
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 $array_gfx_chk = !empty($global_config['ucaptcha_area']) ? explode(',', $global_config['ucaptcha_area']) : [];
 $gfx_chk = (!empty($array_gfx_chk) and in_array('m', $array_gfx_chk)) ? 1 : 0;

--- a/modules/users/funcs/lostpass.php
+++ b/modules/users/funcs/lostpass.php
@@ -326,9 +326,10 @@ if ($mailer_mode != 'smtp' and defined('NV_REGISTER_DOMAIN') and $global_config[
     nv_redirect_location(NV_REGISTER_DOMAIN . NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op . '&nv_redirect=' . nv_redirect_encrypt($client_info['selfurl']));
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op, true);
 $page_title = $mod_title = $lang_module['lostpass_page_title'];
 $key_words = $module_info['keywords'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
 $contents = user_lostpass($data);
 

--- a/modules/users/funcs/main.php
+++ b/modules/users/funcs/main.php
@@ -16,21 +16,21 @@ if (isset($array_op[0])) {
     nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name);
 }
 
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name, true);
 $page_title = $module_info['site_title'];
 $key_words = $module_info['keywords'];
 $mod_title = isset($lang_module['main_title']) ? $lang_module['main_title'] : $module_info['custom_title'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name;
 
 if (!defined('NV_IS_ADMIN') and !$global_config['allowuserlogin']) {
     $contents = user_info_exit($lang_module['notallowuserlogin']);
 } else {
     if (!defined('NV_IS_USER')) {
-        $url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=login';
+        $page_url .= '&' . NV_OP_VARIABLE . '=login';
         $nv_redirect = nv_get_redirect();
         if (!empty($nv_redirect)) {
-            $url .= '&nv_redirect=' . $nv_redirect;
+            $page_url .= '&nv_redirect=' . $nv_redirect;
         }
-        nv_redirect_location($url);
+        nv_redirect_location($page_url);
     } else {
         // So nhom dang quan ly
         $user_info['group_manage'] = $db->query('SELECT COUNT(*) FROM ' . NV_MOD_TABLE . '_groups_users WHERE userid=' . $user_info['userid'] . ' AND is_leader=1')->fetchColumn();
@@ -45,6 +45,16 @@ if (!defined('NV_IS_ADMIN') and !$global_config['allowuserlogin']) {
 
         $contents = user_welcome($array_field_config, $custom_fields);
     }
+}
+
+$base_url_rewrite = nv_url_rewrite($page_url, true);
+$base_url_rewrite_location = str_replace('&amp;', '&', $base_url_rewrite);
+if ($_SERVER['REQUEST_URI'] == $base_url_rewrite_location) {
+    $canonicalUrl = NV_MAIN_DOMAIN . $base_url_rewrite;
+} elseif (NV_MAIN_DOMAIN . $_SERVER['REQUEST_URI'] != $base_url_rewrite_location) {
+    nv_redirect_location($base_url_rewrite_location);
+} else {
+    $canonicalUrl = $base_url_rewrite;
 }
 
 include NV_ROOTDIR . '/includes/header.php';

--- a/modules/users/funcs/memberlist.php
+++ b/modules/users/funcs/memberlist.php
@@ -15,6 +15,7 @@ if (!defined('NV_IS_MOD_USER')) {
 $page_title = $module_info['funcs'][$op]['func_site_title'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['listusers'];
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
 
 if (!nv_user_in_groups($global_config['whoviewuser'])) {
     header('Location: ' . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name));
@@ -35,6 +36,9 @@ if (isset($array_op[1]) and !empty($array_op[1])) {
     if (preg_match('/^(.*)\-([a-z0-9]{32})$/', $array_op[1], $matches)) {
         $md5 = $matches[2];
     }
+
+    $page_url .= '/' . $array_op[1];
+    $canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 
     if (!empty($md5)) {
         $stmt = $db->prepare('SELECT * FROM ' . NV_MOD_TABLE . ' WHERE md5username = :md5' . (defined('NV_IS_ADMIN') ? '' : ' AND active=1'));
@@ -101,6 +105,8 @@ if (isset($array_op[1]) and !empty($array_op[1])) {
     $sortby = $nv_Request->get_string('sortby', 'get', 'DESC');
     $page = $nv_Request->get_int('page', 'get', 1);
 
+    $page_url .= '&orderby=' . $orderby . '&sortby=' . $sortby;
+
     // Kiem tra du lieu hop chuan
     if ((!empty($orderby) and !in_array($orderby, array(
         'username',
@@ -113,7 +119,7 @@ if (isset($array_op[1]) and !empty($array_op[1])) {
         nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name);
     }
 
-    $base_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $op . '&orderby=' . $orderby . '&sortby=' . $sortby;
+    $base_url = $page_url;
 
     $per_page = 25;
     $array_order = array(
@@ -177,6 +183,7 @@ if (isset($array_op[1]) and !empty($array_op[1])) {
     // Tieu de khi phan trang
     if ($page > 1) {
         $page_title .= NV_TITLEBAR_DEFIS . sprintf($lang_module['page'], ceil($page / $per_page));
+        $page_url .= '&page=' . $page;
     }
 
     $generate_page = nv_generate_page($base_url, $num_items, $per_page, $page);
@@ -184,6 +191,8 @@ if (isset($array_op[1]) and !empty($array_op[1])) {
     unset($result, $item);
 
     $contents = nv_memberslist_theme($users_array, $array_order_new, $generate_page);
+
+    $canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
 }
 
 include NV_ROOTDIR . '/includes/header.php';

--- a/modules/users/funcs/register.php
+++ b/modules/users/funcs/register.php
@@ -17,6 +17,9 @@ if (defined('NV_IS_USER') and !defined('ACCESS_ADDUS')) {
     nv_redirect_location(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name);
 }
 
+$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op;
+$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
+
 // Ngung dang ki thanh vien
 if (!$global_config['allowuserreg']) {
     $page_title = $lang_module['register'];
@@ -230,7 +233,6 @@ if (defined('NV_IS_USER') and defined('ACCESS_ADDUS')) {
 }
 
 // Dang ky thong thuong
-$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite(NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&' . NV_NAME_VARIABLE . '=' . $module_name . '&' . NV_OP_VARIABLE . '=' . $op, true);
 $page_title = $lang_module['register'];
 $key_words = $module_info['keywords'];
 $mod_title = $lang_module['register'];

--- a/themes/default/blocks/global.QR_code.php
+++ b/themes/default/blocks/global.QR_code.php
@@ -105,7 +105,7 @@ if (!nv_function_exists('nv_block_qr_code')) {
      */
     function nv_block_qr_code($block_config)
     {
-        global $page_title, $global_config, $client_info, $lang_global;
+        global $page_title, $global_config, $page_url, $module_name, $home, $op, $lang_global;
 
         if (file_exists(NV_ROOTDIR . '/themes/' . $global_config['module_theme'] . '/blocks/global.QR_code.tpl')) {
             $block_theme = $global_config['module_theme'];
@@ -119,7 +119,20 @@ if (!nv_function_exists('nv_block_qr_code')) {
         $xtpl->assign('LANG', $lang_global);
         $xtpl->assign('NV_BASE_SITEURL', NV_BASE_SITEURL);
 
-        $block_config['selfurl'] = $client_info['selfurl'];
+        if (empty($page_url)) {
+            if ($home) {
+                $current_page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA;
+            } else {
+                $current_page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
+                if ($op != 'main') {
+                    $current_page_url .= '&amp;' . NV_OP_VARIABLE . '=' . $op;
+                }
+            }
+        } else {
+            $current_page_url = $page_url;
+        }
+
+        $block_config['selfurl'] = NV_MAIN_DOMAIN . nv_url_rewrite($current_page_url, true);
         $block_config['title'] = "QR-Code: " . str_replace('"', "&quot;", ($page_title ? $page_title : $global_config['site_name']));
         $xtpl->assign('QRCODE', $block_config);
 

--- a/themes/default/modules/news/detail.tpl
+++ b/themes/default/modules/news/detail.tpl
@@ -216,7 +216,7 @@
 <div class="news_column panel panel-default">
     <div class="panel-body" style="margin-bottom:0">
         <div style="display:flex;align-items:flex-start;">
-            <!-- BEGIN: facebook --><div class="margin-right"><div class="fb-like" style="float:left!important;margin-right:0!important" data-href="{SELFURL}" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true"></div></div><!-- END: facebook -->
+            <!-- BEGIN: facebook --><div class="margin-right"><div class="fb-like" style="float:left!important;margin-right:0!important" data-href="{DETAIL.link}" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true"></div></div><!-- END: facebook -->
             <!-- BEGIN: twitter --><div class="margin-right"><a href="http://twitter.com/share" class="twitter-share-button">Tweet</a></div><!-- END: twitter -->
             <!-- BEGIN: zalo --><div><div class="zalo-share-button" data-href="" data-oaid="{ZALO_OAID}" data-layout="1" data-color="blue" data-customize=false></div></div><!-- END: zalo -->
         </div>

--- a/themes/default/modules/page/main.tpl
+++ b/themes/default/modules/page/main.tpl
@@ -23,7 +23,7 @@
         <!-- BEGIN: socialbutton -->
         <div class="margin-bottom">
             <div style="display:flex;align-items:flex-start;">
-                <!-- BEGIN: facebook --><div class="margin-right"><div class="fb-like" style="float:left!important;margin-right:0!important" data-href="{SELFURL}" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true"></div></div><!-- END: facebook -->
+                <!-- BEGIN: facebook --><div class="margin-right"><div class="fb-like" style="float:left!important;margin-right:0!important" data-href="{CONTENT.link}" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true"></div></div><!-- END: facebook -->
                 <!-- BEGIN: twitter --><div class="margin-right"><a href="http://twitter.com/share" class="twitter-share-button">Tweet</a></div><!-- END: twitter -->
                 <!-- BEGIN: zalo --><div><div class="zalo-share-button" data-href="" data-oaid="{ZALO_OAID}" data-layout="1" data-color="blue" data-customize=false></div></div><!-- END: zalo -->
             </div>

--- a/themes/mobile_default/blocks/global.QR_code.php
+++ b/themes/mobile_default/blocks/global.QR_code.php
@@ -105,7 +105,7 @@ if (!nv_function_exists('nv_block_qr_code')) {
      */
     function nv_block_qr_code($block_config)
     {
-        global $page_title, $global_config, $client_info, $lang_global;
+        global $page_title, $global_config, $page_url, $module_name, $home, $op, $lang_global;
 
         if (file_exists(NV_ROOTDIR . '/themes/' . $global_config['module_theme'] . '/blocks/global.QR_code.tpl')) {
             $block_theme = $global_config['module_theme'];
@@ -119,7 +119,20 @@ if (!nv_function_exists('nv_block_qr_code')) {
         $xtpl->assign('LANG', $lang_global);
         $xtpl->assign('NV_BASE_SITEURL', NV_BASE_SITEURL);
 
-        $block_config['selfurl'] = $client_info['selfurl'];
+        if (empty($page_url)) {
+            if ($home) {
+                $current_page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA;
+            } else {
+                $current_page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name;
+                if ($op != 'main') {
+                    $current_page_url .= '&amp;' . NV_OP_VARIABLE . '=' . $op;
+                }
+            }
+        } else {
+            $current_page_url = $page_url;
+        }
+
+        $block_config['selfurl'] = NV_MAIN_DOMAIN . nv_url_rewrite($current_page_url, true);
         $block_config['title'] = "QR-Code: " . str_replace('"', "&quot;", ($page_title ? $page_title : $global_config['site_name']));
         $xtpl->assign('QRCODE', $block_config);
 

--- a/themes/mobile_default/modules/news/detail.tpl
+++ b/themes/mobile_default/modules/news/detail.tpl
@@ -118,7 +118,7 @@
         <hr />
         <!-- BEGIN: socialbutton -->
         <div style="display:flex;align-items:flex-start;">
-            <!-- BEGIN: facebook --><div class="margin-right"><div class="fb-like" style="float:left!important;margin-right:0!important;margin-bottom:0!important;top:0!important" data-href="{SELFURL}" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true"></div></div><!-- END: facebook -->
+            <!-- BEGIN: facebook --><div class="margin-right"><div class="fb-like" style="float:left!important;margin-right:0!important;margin-bottom:0!important;top:0!important" data-href="{DETAIL.link}" data-layout="button_count" data-action="like" data-show-faces="false" data-share="true"></div></div><!-- END: facebook -->
             <!-- BEGIN: twitter --><div class="margin-right"><a href="http://twitter.com/share" class="twitter-share-button">Tweet</a></div><!-- END: twitter -->
             <!-- BEGIN: zalo --><div><div class="zalo-share-button" data-href="" data-oaid="{ZALO_OAID}" data-layout="1" data-color="blue" data-customize=false></div></div><!-- END: zalo -->
         </div>

--- a/themes/mobile_default/modules/news/theme.php
+++ b/themes/mobile_default/modules/news/theme.php
@@ -611,7 +611,6 @@ function detail_theme($news_contents, $array_keyword, $related_new_array, $relat
     $xtpl->assign('NEWSID', $news_contents['id']);
     $xtpl->assign('NEWSCHECKSS', $news_contents['newscheckss']);
     $xtpl->assign('DETAIL', $news_contents);
-    $xtpl->assign('SELFURL', $client_info['selfurl']);
 
     if ($news_contents['allowed_send'] == 1) {
         $xtpl->assign('URL_SENDMAIL', $news_contents['url_sendmail']);


### PR DESCRIPTION
Lỗi Cross-site Scripting (XSS) tiềm ẩn
Theo thông báo của acunetix.com, tất cả các website sử dụng NukeViet đang mắc lỗi bảo mật Cross-site Scripting (XSS) (XSS xảy ra khi một ứng dụng web sử dụng dữ liệu đầu vào của người dùng chưa được xác thực hoặc chưa được mã hóa trong đầu ra mà nó tạo ra).
Acunetix.com đưa ra dẫn chứng là:
```html
http://nukeviet.site/Ban-tin-noi-bo/hay-tro-thanh-nha-cung-cap-dich-vu-cua-nukeviet-6.html?%F6"onmouseover=iIbe(99255)//
```
và:
```html
http://nukeviet.site/en/news/?wvstest=javascript:domxssExecutionSink(1,"'\"><xsstag>()locxss")?javascript:domxssExecutionSink(1,"'\"><xsstag>()locxss")#javascript:domxssExecutionSink(1,"'\"><xsstag>()locxss")
```
Khi view source của trang, đoạn mã được chèn vào có tồn tại, nhưng các ký tự đặc biệt của nó đã bị mã hóa, mất khả năng thực thi. Theo đánh giá của chúng tôi, cách chèn mã độc kiểu này hoàn toàn bị vô hiệu ở NukeViet.
Nhưng ở đây cho thấy nguy cơ tiềm ẩn sau: Biến $client_info['selfurl'] bê nguyên giá trị của GET (dòng địa chỉ của trình duyệt), mã hóa các ký tự đặc biệt và cho ra kết quả để hiển thị trong phần HTML-output. Như vậy chúng ta không thể kiểm soát được nội dung của biến $client_info['selfurl'] có hợp lệ hay không. Nếu không khắc phục vấn đề này, $client_info['selfurl'] sẽ là mảnh đất màu mỡ để các hacker đào sâu sau này.

**Hướng khắc phục:**
Chỗ nào có $client_info['selfurl'] được lấy để hiển thị ra bên ngoài - chỗ đó cần thay bằng URL có kiểm duyệt.
Ví dụ:
Trong file modules/News/theme.php, dòng 767:
```php
$xtpl->assign('SELFURL', $client_info['selfurl']);
```
Cần thay là:
```html
$xtpl->assign('SELFURL', $news_contents['link']);
```
Trong đó $news_contents['link'] là URL chuẩn đến trang đang xử lý chứ không phải là URL do người dùng tự nhập.

**function nv_rss_generate($channel, $items)**
Function này hiện đang gán cho biến $atomlink giá trị là $client_info['selfurl'].
Cách fix:
Trong nhân hệ thống đã thay đổi function này với 3 đối số bắt buộc: $channel, $items, $atomlink.
Chỗ nào gọi hàm nv_rss_generate($channel, $items) chỗ đó cần thay bằng:
```php
$atomlink = NV_BASE_SITEURL . "index.php?" . NV_LANG_VARIABLE . "=" . NV_LANG_DATA . "&amp;" . NV_NAME_VARIABLE . "=" . $module_name . "&amp;" . NV_OP_VARIABLE . "=" . $module_info['alias']['rss'];
nv_rss_generate($channel, $items, $atomlink);
```

**funtion nv_html_meta_tags**
Trong function này cũng dùng $client_info['selfurl'] để gán cho biến $site_description khi nó rỗng.
Để tránh việc dùng $client_info['selfurl'] không qua kiểm duyệt, thêm vào biến $page_url được định nghĩa ở từng trang của module với giá trị chính là đường dẫn tuyệt đối từ thư mục gốc đến trang đang xử lý.
Ví dụ:
```php
$page_url = NV_BASE_SITEURL . 'index.php?' . NV_LANG_VARIABLE . '=' . NV_LANG_DATA . '&amp;' . NV_NAME_VARIABLE . '=' . $module_name . '&amp;' . NV_OP_VARIABLE . '=' . $op;
```
Lúc đó, biến $canonicalUrl sẽ được xác định là:
```php
$canonicalUrl = NV_MAIN_DOMAIN . nv_url_rewrite($page_url, true);
```