### PR TITLE
Support location: hash in link menu

### DIFF
--- a/modules/menu/admin/rows.php
+++ b/modules/menu/admin/rows.php
@@ -214,7 +214,7 @@ if ($nv_Request->isset_request('submit1', 'post')) {
         $post['image'] = '';
     }
 
-    if (!empty($post['link']) and !nv_is_url($post['link'], true)) {
+    if (!empty($post['link']) and !nv_is_url($post['link'], true) and !preg_match('/^\#[a-zA-Z0-9\-\_]*$/', $post['link'])) {
         $post['link'] = '';
     }
 

--- a/modules/news/admin/main.php
+++ b/modules/news/admin/main.php
@@ -1017,6 +1017,11 @@ if (!empty($data) and !empty($module_config[$module_name]['active_history'])) {
     }
 }
 
+if ($num_items > 0) {
+    $xtpl->assign('NUMRESULTS', number_format($num_items, 0, ',', '.'));
+    $xtpl->parse('main.numresults');
+}
+
 $url_copy = '';
 $loadhistory = $nv_Request->get_absint('loadhistory', 'get', 0);
 $loadhistory_id = 0;

--- a/modules/news/language/admin_en.php
+++ b/modules/news/language/admin_en.php
@@ -61,6 +61,7 @@ $lang_module['error_name'] = 'Error: Please add title';
 $lang_module['weight'] = 'Position';
 $lang_module['numsubcat'] = 'Number of sub-categories';
 $lang_module['numlinks'] = 'Number of link';
+$lang_module['numresults'] = 'Number of results';
 $lang_module['numcomments'] = 'Number comments';
 $lang_module['numtags'] = 'Number tags';
 $lang_module['newday'] = 'Show new icon (day)';

--- a/modules/news/language/admin_fr.php
+++ b/modules/news/language/admin_fr.php
@@ -61,6 +61,7 @@ $lang_module['error_name'] = 'Erreur: Manque de titre';
 $lang_module['weight'] = 'Position';
 $lang_module['numsubcat'] = 'Nombre de sous-catégories';
 $lang_module['numlinks'] = 'Nombre de liens';
+$lang_module['numresults'] = 'Nombre de résultats';
 $lang_module['numcomments'] = 'Nombre de commentaire';
 $lang_module['numtags'] = 'Nombre de tags';
 $lang_module['newday'] = 'Icone des nouvelles (par jour)';

--- a/modules/news/language/admin_vi.php
+++ b/modules/news/language/admin_vi.php
@@ -60,6 +60,7 @@ $lang_module['error_name'] = 'Lỗi:Bạn cần nhập Tiêu đề';
 $lang_module['weight'] = 'Vị trí';
 $lang_module['numsubcat'] = 'Số chuyên mục con';
 $lang_module['numlinks'] = 'Số liên kết';
+$lang_module['numresults'] = 'Số kết quả';
 $lang_module['numcomments'] = 'Số bình luận';
 $lang_module['numtags'] = 'Số tags';
 $lang_module['newday'] = 'Icon tin mới (ngày)';

--- a/themes/admin_default/modules/news/main.tpl
+++ b/themes/admin_default/modules/news/main.tpl
@@ -110,7 +110,9 @@
         <label><em>{LANG.search_note}</em></label>
     </form>
 </div>
-
+<div class="text-right">
+    <p>{LANG.numresults}: <strong class="text-danger">{NUMRESULTS}</strong></p>
+</div>
 <form class="navbar-form" name="block_list" action="{NV_BASE_ADMINURL}index.php?{NV_LANG_VARIABLE}={NV_LANG_DATA}&{NV_NAME_VARIABLE}={MODULE_NAME}&amp;{NV_OP_VARIABLE}={OP}">
     <div class="table-responsive">
         <table class="table table-striped table-bordered table-hover">


### PR DESCRIPTION
Mô tả:
Nhiều website có nhu cầu nhập link đơn giản chỉ có location hash ví dụ #giai-thuong #doi-tac .. hiện tại không nhập được.