### PR TITLE
Fix breadcrumb error when zooming the screen nukeviet 4.5

### DIFF
--- a/themes/default/css/style.css
+++ b/themes/default/css/style.css
@@ -940,6 +940,7 @@ a.btn {
     border-style: solid;
     border-color: #dcdcdc #dcdcdc #dcdcdc transparent;
     left: -1em;
+    padding-right: 1px;
 }
 
 .breadcrumbs a:hover:before {
@@ -962,6 +963,7 @@ a.btn {
     border-left-style: solid;
     border-left-color: #dcdcdc;
     right: -1em;
+    padding-right: 1px;
 }
 
 .breadcrumbs a:hover:after,


### PR DESCRIPTION
When zooming the breadcrumb screen will be stretched by 1px

![image](https://github.com/nukeviet/nukeviet/assets/9360175/0911e82b-4cef-4c37-8b0a-912c8826b47e)
