### PR TITLE
Fix breadcrumb error when zooming the screen nukeviet 4.6

### DIFF
--- a/themes/default/css/style.css
+++ b/themes/default/css/style.css
@@ -997,6 +997,7 @@ a.btn {
     border-style: solid;
     border-color: #dcdcdc #dcdcdc #dcdcdc transparent;
     left: -1em;
+    padding-right: 1px;
 }
 
 .breadcrumbs a:hover:before {
@@ -1019,6 +1020,7 @@ a.btn {
     border-left-style: solid;
     border-left-color: #dcdcdc;
     right: -1em;
+    padding-left: 1px
 }
 
 .breadcrumbs a:hover:after,


### PR DESCRIPTION
When zooming the breadcrumb screen will be stretched by 1px

![image](https://github.com/nukeviet/nukeviet/assets/9360175/0911e82b-4cef-4c37-8b0a-912c8826b47e)