### PR TITLE
Update function: nv_compound_unicode in case $nv_Request null

### DIFF
--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -4230,10 +4230,10 @@ function nv_uuid4()
 
 /**
  * Hàm chuyển Unicode tổ hợp sang Unicode dựng sẵn
- * @param mixed $str
+ * @param mixed $value
  * @return mixed
  */
-function nv_compound_unicode($str)
+function nv_compound_unicode($value)
 {
     global $nv_Request, $global_config;
 
@@ -4241,5 +4241,5 @@ function nv_compound_unicode($str)
         $nv_Request = new NukeViet\Core\Request($global_config, null);
     }
 
-    return $nv_Request->compound_unicode($str);
+    return $nv_Request->compound_unicode($value);
 }

--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -4230,12 +4230,16 @@ function nv_uuid4()
 
 /**
  * Hàm chuyển Unicode tổ hợp sang Unicode dựng sẵn
- * @param string $str
- * @return string
+ * @param mixed $str
+ * @return mixed
  */
 function nv_compound_unicode($str)
 {
-    global $nv_Request;
+    global $nv_Request, $global_config;
+
+    if (empty($nv_Request)) {
+        $nv_Request = new NukeViet\Core\Request($global_config, null);
+    }
 
     return $nv_Request->compound_unicode($str);
 }

--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -4235,11 +4235,5 @@ function nv_uuid4()
  */
 function nv_compound_unicode($value)
 {
-    global $nv_Request, $global_config;
-
-    if (empty($nv_Request)) {
-        $nv_Request = new NukeViet\Core\Request($global_config, null);
-    }
-
-    return $nv_Request->compound_unicode($value);
+    return NukeViet\Core\Request::compound_unicode($value);
 }

--- a/src/includes/vendor/vinades/nukeviet/Core/Request.php
+++ b/src/includes/vendor/vinades/nukeviet/Core/Request.php
@@ -1080,7 +1080,7 @@ class Request
                         if (empty($value) or is_numeric($value)) {
                             return $value;
                         }
-                        $value = $this->compound_unicode($value);
+                        $value = self::compound_unicode($value);
                         return ($filter == true) ? $this->security_get($value) : $value;
                     }
                     break;
@@ -1090,7 +1090,7 @@ class Request
                         if (empty($value) or is_numeric($value)) {
                             return $value;
                         }
-                        $value = $this->compound_unicode($value);
+                        $value = self::compound_unicode($value);
                         return ($filter == true) ? $this->security_post($value) : $value;
                     }
                     break;
@@ -1125,7 +1125,7 @@ class Request
                         if (empty($value) or is_numeric($value)) {
                             return $value;
                         }
-                        $value = $this->compound_unicode($value);
+                        $value = self::compound_unicode($value);
                         return ($filter == true) ? $this->security_post($value) : $value;
                     }
                     if (array_key_exists($name, $_GET)) {
@@ -1133,7 +1133,7 @@ class Request
                         if (empty($value) or is_numeric($value)) {
                             return $value;
                         }
-                        $value = $this->compound_unicode($value);
+                        $value = self::compound_unicode($value);
                         return ($filter == true) ? $this->security_get($value) : $value;
                     }
                     break;
@@ -1715,12 +1715,12 @@ class Request
      * @param mixed $value
      * @return mixed
      */
-    public function compound_unicode($value)
+    public static function compound_unicode($value)
     {
         if (is_array($value)) {
             $keys = array_keys($value);
             foreach ($keys as $key) {
-                $value[$key] = $this->compound_unicode($value[$key]);
+                $value[$key] = self::compound_unicode($value[$key]);
             }
         } elseif (is_string($value)) {
             // Sử dụng Normalizer nếu extension intl được cài đặt


### PR DESCRIPTION
Một số trường hợp gọi hàm `nv_compound_unicode` ở giao diện console không khởi tạo request, dẫn đến `$nv_Request = null`

Nên em bổ sung check nếu null thì `new **Request**` để không cần viết lặp lại code