### PR TITLE
feat: add logout hook for custom session cleanup

### DIFF
--- a/src/includes/mainfile.php
+++ b/src/includes/mainfile.php
@@ -23,7 +23,7 @@ define('NV_START_TIME', microtime(true));
 define('NV_CURRENTTIME', $_SERVER['REQUEST_TIME'] ?? time());
 
 // Khong cho xac dinh tu do cac variables
-$db_config = $global_config = $module_config = $client_info = $user_info = $admin_info = $sys_info = $lang_global = $lang_module = $rss = $nv_vertical_menu = $array_mod_title = $content_type = $submenu = $error_info = $countries = $loadScript = $headers = $theme_config = $nv_hooks = $nv_plugins = $custom_preloads = $user_cookie = $nv_html_links = $nv_schemas = $strdata = $meta_property = [];
+$db_config = $global_config = $module_config = $client_info = $user_info = $admin_info = $sys_info = $lang_global = $lang_module = $rss = $nv_vertical_menu = $array_mod_title = $content_type = $submenu = $error_info = $countries = $loadScript = $headers = $theme_config = $nv_hooks = $nv_plugins = $custom_preloads = $user_cookie = $nv_html_links = $nv_schemas = $strdata = $meta_property = $nv_custom_session_clean = [];
 $page_title = $key_words = $page_url = $canonicalUrl = $prevPage = $nextPage = $my_head = $my_footer = $description = $contents = $csrf_key = '';
 $editor = false;
 

--- a/src/modules/users/funcs/logout.php
+++ b/src/modules/users/funcs/logout.php
@@ -73,6 +73,13 @@ if (defined('NV_IS_USER_FORUM') or defined('SSO_SERVER')) {
 } else {
     $db->query('DELETE FROM ' . NV_MOD_TABLE . '_login WHERE userid=' . $user_info['userid'] . ' AND clid=' . $db->quote($client_info['clid']));
     NukeViet\Core\User::unset_userlogin_hash();
+
+    if (!empty($nv_custom_session_clean)) {
+        nv_apply_hook($module_name, 'clean_custom_session_key', [[
+            'keys' => $nv_custom_session_clean
+        ]]);
+    }
+
     if ($user_info['current_mode'] == 4 and module_file_exists('users/login/cas-' . $user_info['openid_server'] . '.php')) {
         define('CAS_LOGOUT_URL_REDIRECT', $url_redirect);
         include NV_ROOTDIR . '/modules/users/login/cas-' . $user_info['openid_server'] . '.php';

--- a/src/modules/users/hooks/clean_custom_session_value.php
+++ b/src/modules/users/hooks/clean_custom_session_value.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * NukeViet Content Management System
+ * @version 5.x
+ * @author VINADES.,JSC <contact@vinades.vn>
+ * @copyright (C) 2009-2026 VINADES.,JSC. All rights reserved
+ * @license GNU/GPL version 2 or any later version
+ * @see https://github.com/nukeviet The NukeViet CMS GitHub project
+ */
+
+if (!defined('NV_MAINFILE')) {
+    exit('Stop!!!');
+}
+
+/**
+ * Hook dọn các session key tùy chỉnh sau khi user logout.
+ *
+ * Cách dùng:
+ * - Khai báo các key cần xóa vào biến toàn cục $nv_custom_session_clean.
+ * - Sau khi logout hoàn tất, module users sẽ phát tag clean_custom_session_key.
+ * - Payload hỗ trợ:
+ *   + ['keys' => ['key1', 'key2']]
+ *   + ['keys' => 'key1,key2']
+ */
+$callback = function ($vars, $from_data, $receive_data) {
+    global $nv_Request;
+
+    $keys = $vars['keys'] ?? [];
+    if (is_string($keys)) {
+        $keys = array_map('trim', explode(',', $keys));
+    }
+
+    if (!is_array($keys)) {
+        return null;
+    }
+
+    $keys = array_values(array_filter(array_map(static function ($key) {
+        return is_scalar($key) ? trim((string) $key) : '';
+    }, $keys)));
+
+    if (empty($keys)) {
+        return null;
+    }
+
+    $nv_Request->unset_request(implode(',', $keys), 'session');
+
+    return null;
+};
+
+nv_add_hook($module_name, 'clean_custom_session_key', $priority, $callback, $hook_module, $pid);


### PR DESCRIPTION
## Summary
- add a global `$nv_custom_session_clean` array so developers can declare custom session keys that should be cleared on logout
- fire the `clean_custom_session_key` hook after user logout completes in the users module
- add the `clean_custom_session_value` hook to unset configured session keys via `$nv_Request->unset_request()`